### PR TITLE
Add bulk profile update feature and fix mumu emulator adb compatibility 

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/controller/ProfileManagerActionController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/controller/ProfileManagerActionController.java
@@ -72,6 +72,26 @@ public class ProfileManagerActionController implements IProfileStatusChangeListe
 		return iModel.saveProfile(dtoprofile);
 	}
 
+	public boolean bulkUpdateProfiles(ProfileAux templateProfile) {
+		if (templateProfile == null) {
+			return false;
+		}
+
+		DTOProfiles dtoTemplateProfile = new DTOProfiles(
+			templateProfile.getId(), 
+			templateProfile.getName(), 
+			templateProfile.getEmulatorNumber(), 
+			templateProfile.isEnabled()
+		);
+		
+		templateProfile.getConfigs().forEach(cfgAux -> {
+			DTOConfig dtoConfig = new DTOConfig(templateProfile.getId(), cfgAux.getName(), cfgAux.getValue());
+			dtoTemplateProfile.getConfigs().add(dtoConfig);
+		});
+		
+		return iModel.bulkUpdateProfiles(dtoTemplateProfile);
+	}
+
 	@Override
 	public void onProfileStatusChange(DTOProfileStatus status) {
 		if (status != null) {

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/model/IProfileModel.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/model/IProfileModel.java
@@ -12,8 +12,9 @@ public interface IProfileModel {
 	public boolean addProfile(DTOProfiles profile);
 
 	public boolean saveProfile(DTOProfiles profile);
-
 	public boolean deleteProfile(DTOProfiles profile);
+
+	public boolean bulkUpdateProfiles(DTOProfiles templateProfile);
 
 	public void addProfileStatusChangeListerner(IProfileStatusChangeListener listener);
 

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/model/impl/ProfileModel.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/model/impl/ProfileModel.java
@@ -41,4 +41,9 @@ public class ProfileModel implements IProfileModel {
 		return servProfile.deleteProfile(profile);
 	}
 
+	@Override
+	public boolean bulkUpdateProfiles(DTOProfiles templateProfile) {
+		return servProfile.bulkUpdateProfiles(templateProfile);
+	}
+
 }

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
@@ -23,6 +23,8 @@ import javafx.fxml.FXML;
 import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar.ButtonData;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -57,6 +59,9 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	private TableColumn<ProfileAux, String> columnProfileName;
 	@FXML
 	private TableColumn<ProfileAux, String> columnStatus;
+
+	@FXML
+	private Button btnBulkUpdate;
 
 	private Long loadedProfileId;
 
@@ -274,6 +279,63 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	void handleButtonAddProfile(ActionEvent event) {
 		profileManagerActionController.showNewProfileDialog();
+	}
+
+	@FXML
+	void handleButtonBulkUpdateProfiles(ActionEvent event) {
+		if (loadedProfileId == null) {
+			Alert alert = new Alert(Alert.AlertType.WARNING);
+			alert.setTitle("WARNING");
+			alert.setHeaderText(null);
+			alert.setContentText("Please load a profile first to use as template for bulk update.");
+			alert.showAndWait();
+			return;
+		}
+
+		// Find the currently loaded profile to use as template
+		ProfileAux templateProfile = profiles.stream()
+			.filter(p -> p.getId().equals(loadedProfileId))
+			.findFirst()
+			.orElse(null);
+
+		if (templateProfile == null) {
+			Alert alert = new Alert(Alert.AlertType.ERROR);
+			alert.setTitle("ERROR");
+			alert.setHeaderText(null);
+			alert.setContentText("Could not find the loaded profile to use as template.");
+			alert.showAndWait();
+			return;
+		}
+
+		// Confirm bulk update
+		Alert confirmAlert = new Alert(Alert.AlertType.CONFIRMATION);
+		confirmAlert.setTitle("CONFIRM BULK UPDATE");
+		confirmAlert.setHeaderText("Bulk Update All Profiles");
+		confirmAlert.setContentText("This will apply the current settings from profile '" + 
+			templateProfile.getName() + "' to ALL profiles. This action cannot be undone. Continue?");
+
+		if (confirmAlert.showAndWait().orElse(null) != ButtonType.OK) {
+			return;
+		}
+
+		// Perform bulk update
+		boolean success = profileManagerActionController.bulkUpdateProfiles(templateProfile);
+
+		Alert resultAlert;
+		if (success) {
+			resultAlert = new Alert(Alert.AlertType.INFORMATION);
+			resultAlert.setTitle("SUCCESS");
+			resultAlert.setHeaderText(null);
+			resultAlert.setContentText("All profiles have been updated successfully with settings from '" + 
+				templateProfile.getName() + "'.");
+			loadProfiles(); // Refresh the profiles
+		} else {
+			resultAlert = new Alert(Alert.AlertType.ERROR);
+			resultAlert.setTitle("ERROR");
+			resultAlert.setHeaderText(null);
+			resultAlert.setContentText("Error occurred while updating profiles. Some profiles may not have been updated.");
+		}
+		resultAlert.showAndWait();
 	}
 
 	public void loadProfiles() {

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/ProfileManagerLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/ProfileManagerLayout.fxml
@@ -35,6 +35,11 @@
       </TableView>
       <HBox alignment="CENTER_RIGHT" prefHeight="100.0" prefWidth="200.0" GridPane.rowIndex="1">
          <children>
+            <Button fx:id="btnBulkUpdate" mnemonicParsing="false" onAction="#handleButtonBulkUpdateProfiles" text="BULK UPDATE PROFILES">
+               <HBox.margin>
+                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
+               </HBox.margin>
+            </Button>
             <Button fx:id="btnAddProfile" mnemonicParsing="false" onAction="#handleButtonAddProfile" text="ADD PROFILE">
                <HBox.margin>
                   <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />

--- a/wos-serv/src/main/java/cl/camodev/wosbot/emulator/impl/MuMuEmulator.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/emulator/impl/MuMuEmulator.java
@@ -14,7 +14,7 @@ public class MuMuEmulator extends Emulator {
 
 	@Override
 	protected String[] buildAdbCommand(String emulatorNumber, String command) {
-		return new String[] { consolePath + File.separator + "MuMuManager.exe", "adb", "-v", emulatorNumber, command };
+		return new String[] { consolePath + File.separator + "MuMuManager.exe", "adb", "-v", emulatorNumber, "-c", command };
 	}
 
 	@Override

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/IServProfile.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/IServProfile.java
@@ -11,8 +11,9 @@ public interface IServProfile {
 	public boolean addProfile(DTOProfiles profile);
 
 	public boolean saveProfile(DTOProfiles profile);
-
 	public boolean deleteProfile(DTOProfiles profile);
+
+	public boolean bulkUpdateProfiles(DTOProfiles templateProfile);
 
 	public void addProfileStatusChangeListerner(IProfileStatusChangeListener listener);
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServProfiles.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServProfiles.java
@@ -150,6 +150,56 @@ public class ServProfiles implements IServProfile {
 		}
 	}
 
+	@Override
+	public boolean bulkUpdateProfiles(DTOProfiles templateProfile) {
+		try {
+			if (templateProfile == null) {
+				return false;
+			}
+
+			// Get all profiles
+			List<DTOProfiles> allProfiles = getProfiles();
+			
+			if (allProfiles == null || allProfiles.isEmpty()) {
+				return false;
+			}
+
+			boolean allSuccessful = true;
+
+			for (DTOProfiles profile : allProfiles) {
+				try {
+					// Create a copy of the profile with updated configurations
+					DTOProfiles updatedProfile = new DTOProfiles(
+						profile.getId(), 
+						profile.getName(), 
+						profile.getEmulatorNumber(), 
+						profile.getEnabled()
+					);
+					
+					// Copy all configurations from template profile
+					updatedProfile.getConfigs().clear();
+					updatedProfile.getConfigs().addAll(templateProfile.getConfigs());
+					
+					// Save the updated profile
+					boolean saved = saveProfile(updatedProfile);
+					if (!saved) {
+						allSuccessful = false;
+						System.err.println("Failed to update profile: " + profile.getName());
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+					allSuccessful = false;
+				}
+			}
+
+			return allSuccessful;
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
+
 	public void notifyProfileStatusChange(DTOProfileStatus statusDto) {
 		if (listeners != null) {
 			listeners.forEach(listener -> {


### PR DESCRIPTION
- Added a 'Bulk Update Profiles' button next to the Add Profile button that allows users to apply the current profile's settings to all profiles at once, with confirmation dialog and proper error handling.

![image](https://github.com/user-attachments/assets/0a3bb012-5995-4c41-a060-c40fa2054ed8)

- Added `-c` flag to ADB command in `MuMuEmulator`. Without the flag I was getting unknown command error from adb due to command being sent as a single string causing a confusion (might be a version related, I am using latest version of Mumu player). https://github.com/camoloqlo/wosbot/compare/master...mrcolak:wosbot:master#diff-a47398528dec62e1b34cba5850d8b515b9d862916931db24aa8c314f27b9c4e9

_Here is a demonstration, c flag works both with and without quotes so the issue solved for me;_
![image](https://github.com/user-attachments/assets/e26f1456-2db5-4acf-b606-0d28b9d2cbc1)