### PR TITLE
Added various features and fixes, see description for details

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/gather/view/GatherLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/gather/view/GatherLayoutController.java
@@ -4,6 +4,7 @@ import cl.camodev.wosbot.common.view.AbstractProfileController;
 import cl.camodev.wosbot.console.enumerable.EnumConfigurationKey;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 
 public class GatherLayoutController extends AbstractProfileController {
@@ -28,9 +29,11 @@ public class GatherLayoutController extends AbstractProfileController {
 
 	@FXML
 	private TextField textfieldLevelMeat;
-
 	@FXML
 	private TextField textfieldLevelWood;
+
+	@FXML
+	private ComboBox<Integer> comboBoxActiveMarchQueue;
 
 	@FXML
 	private void initialize() {
@@ -39,11 +42,14 @@ public class GatherLayoutController extends AbstractProfileController {
 		checkBoxMappings.put(checkBoxGatherIron, EnumConfigurationKey.GATHER_IRON_BOOL);
 		checkBoxMappings.put(checkBoxGatherMeat, EnumConfigurationKey.GATHER_MEAT_BOOL);
 		checkBoxMappings.put(checkBoxGatherWood, EnumConfigurationKey.GATHER_WOOD_BOOL);
-
 		textFieldMappings.put(textfieldLevelCoal, EnumConfigurationKey.GATHER_COAL_LEVEL_INT);
 		textFieldMappings.put(textfieldLevelIron, EnumConfigurationKey.GATHER_IRON_LEVEL_INT);
 		textFieldMappings.put(textfieldLevelMeat, EnumConfigurationKey.GATHER_MEAT_LEVEL_INT);
 		textFieldMappings.put(textfieldLevelWood, EnumConfigurationKey.GATHER_WOOD_LEVEL_INT);
+
+		// Initialize ComboBox with values 1-6
+		comboBoxActiveMarchQueue.getItems().addAll(1, 2, 3, 4, 5, 6);
+		comboBoxMappings.put(comboBoxActiveMarchQueue, EnumConfigurationKey.GATHER_ACTIVE_MARCH_QUEUE_INT);
 
 		initializeChangeEvents();
 	}

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/gather/view/GatherLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/gather/view/GatherLayoutController.java
@@ -31,17 +31,19 @@ public class GatherLayoutController extends AbstractProfileController {
 	private TextField textfieldLevelMeat;
 	@FXML
 	private TextField textfieldLevelWood;
-
 	@FXML
 	private ComboBox<Integer> comboBoxActiveMarchQueue;
 
 	@FXML
-	private void initialize() {
+	private CheckBox checkBoxGatherSpeedBoost;
 
+	@FXML
+	private void initialize() {
 		checkBoxMappings.put(checkBoxGatherCoal, EnumConfigurationKey.GATHER_COAL_BOOL);
 		checkBoxMappings.put(checkBoxGatherIron, EnumConfigurationKey.GATHER_IRON_BOOL);
 		checkBoxMappings.put(checkBoxGatherMeat, EnumConfigurationKey.GATHER_MEAT_BOOL);
 		checkBoxMappings.put(checkBoxGatherWood, EnumConfigurationKey.GATHER_WOOD_BOOL);
+		checkBoxMappings.put(checkBoxGatherSpeedBoost, EnumConfigurationKey.GATHER_SPEED_BOOL);
 		textFieldMappings.put(textfieldLevelCoal, EnumConfigurationKey.GATHER_COAL_LEVEL_INT);
 		textFieldMappings.put(textfieldLevelIron, EnumConfigurationKey.GATHER_IRON_LEVEL_INT);
 		textFieldMappings.put(textfieldLevelMeat, EnumConfigurationKey.GATHER_MEAT_LEVEL_INT);

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/launcher/view/LauncherActionController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/launcher/view/LauncherActionController.java
@@ -20,13 +20,12 @@ public class LauncherActionController implements IBotStateListener {
 	public void stopBot() {
 		ServScheduler.getServices().stopBot();
 	}
-
 	public void pauseBot() {
-//		ServScheduler.getServices().pauseBot();
+		ServScheduler.getServices().pauseBot();
 	}
 
 	public void resumeBot() {
-
+		ServScheduler.getServices().resumeBot();
 	}
 
 	public void captureScreenshots() {

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/launcher/view/LauncherLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/launcher/view/LauncherLayoutController.java
@@ -53,9 +53,11 @@ public class LauncherLayoutController implements IProfileLoadListener {
 
 	@FXML
 	private VBox buttonsContainer;
-
 	@FXML
 	private Button buttonStartStop;
+
+	@FXML
+	private Button buttonPauseResume;
 
 	@FXML
 	private AnchorPane mainContentPane;
@@ -264,7 +266,6 @@ public class LauncherLayoutController implements IProfileLoadListener {
 		addButton("ConsoleLogLayout", "Logs", consoleLogLayoutController).fire();
 
 	}
-
 	@FXML
 	public void handleButtonStartStop(ActionEvent event) {
 		if (!estado) {
@@ -272,7 +273,15 @@ public class LauncherLayoutController implements IProfileLoadListener {
 		} else {
 			actionController.stopBot();
 		}
+	}
 
+	@FXML
+	public void handleButtonPauseResume(ActionEvent event) {
+		if (buttonPauseResume.getText().equals("Pause Bot")) {
+			actionController.pauseBot();
+		} else {
+			actionController.resumeBot();
+		}
 	}
 
 	private Button addButton(String fxmlName, String title, Object controller) {
@@ -351,30 +360,40 @@ public class LauncherLayoutController implements IProfileLoadListener {
 		}
 
 	}
-
 	@Override
 	public void onProfileLoad(ProfileAux profile) {
 		stage.setTitle("Whiteout Survival Bot - " + profile.getName());
 		buttonStartStop.setDisable(false);
-
+		buttonPauseResume.setDisable(true);
 	}
 
 	public void onBotStateChange(DTOBotState botState) {
 		if (botState != null) {
 			if (botState.getRunning()) {
-				buttonStartStop.setText("Stop");
-				estado = true;
-
-//				startTime = LocalDateTime.now();
-//				startUpdatingExecutionTime();
+				if (botState.getPaused() != null && botState.getPaused()) {
+					// Bot is running but paused
+					buttonStartStop.setText("Stop");
+					buttonStartStop.setDisable(false);
+					buttonPauseResume.setText("Resume Bot");
+					buttonPauseResume.setDisable(false);
+					estado = true;
+				} else {
+					// Bot is running and active
+					buttonStartStop.setText("Stop");
+					buttonStartStop.setDisable(false);
+					buttonPauseResume.setText("Pause Bot");
+					buttonPauseResume.setDisable(false);
+					estado = true;
+				}
 			} else {
-				buttonStartStop.setText("Start");
+				// Bot is stopped
+				buttonStartStop.setText("Start Bot");
+				buttonStartStop.setDisable(false);
+				buttonPauseResume.setText("Pause Bot");
+				buttonPauseResume.setDisable(true);
 				estado = false;
-
-//				stopUpdatingExecutionTime();
 			}
 		}
-
 	}
 
 }

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/gather/view/GatherLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/gather/view/GatherLayout.fxml
@@ -16,11 +16,12 @@
       <ColumnConstraints hgrow="SOMETIMES" percentWidth="50.0" />
   </columnConstraints>
   <rowConstraints>
-    <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
+    <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="16.666" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="16.666" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="16.666" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="16.666" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="16.666" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="16.666" prefHeight="277.0" vgrow="SOMETIMES" />
   </rowConstraints>
    <children>
       <CheckBox fx:id="checkBoxGatherMeat" graphicTextGap="3.0" mnemonicParsing="false" text="Gather Meat">
@@ -59,7 +60,7 @@
             <TextField fx:id="textfieldLevelIron" />
          </children>
       </HBox>
-      <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="4">
+      <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="5">
          <children>
             <Label text="Active March Queue:" />
             <ComboBox fx:id="comboBoxActiveMarchQueue" prefWidth="150.0" />
@@ -68,5 +69,10 @@
             <Insets left="10.0" />
          </GridPane.margin>
       </HBox>
+      <CheckBox fx:id="checkBoxGatherSpeedBoost" graphicTextGap="3.0" mnemonicParsing="false" text="Gather Speed Boost (250 gems)" GridPane.columnSpan="2" GridPane.rowIndex="4">
+         <GridPane.margin>
+            <Insets left="10.0" />
+         </GridPane.margin>
+      </CheckBox>
    </children>
 </GridPane>

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/gather/view/GatherLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/gather/view/GatherLayout.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.ColumnConstraints?>
@@ -15,10 +16,11 @@
       <ColumnConstraints hgrow="SOMETIMES" percentWidth="50.0" />
   </columnConstraints>
   <rowConstraints>
-    <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="25.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="25.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="25.0" prefHeight="277.0" vgrow="SOMETIMES" />
-      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="25.0" prefHeight="277.0" vgrow="SOMETIMES" />
+    <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" percentHeight="20.0" prefHeight="277.0" vgrow="SOMETIMES" />
   </rowConstraints>
    <children>
       <CheckBox fx:id="checkBoxGatherMeat" graphicTextGap="3.0" mnemonicParsing="false" text="Gather Meat">
@@ -56,6 +58,15 @@
             <Label text="Level" />
             <TextField fx:id="textfieldLevelIron" />
          </children>
+      </HBox>
+      <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="4">
+         <children>
+            <Label text="Active March Queue:" />
+            <ComboBox fx:id="comboBoxActiveMarchQueue" prefWidth="150.0" />
+         </children>
+         <GridPane.margin>
+            <Insets left="10.0" />
+         </GridPane.margin>
       </HBox>
    </children>
 </GridPane>

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
@@ -57,14 +57,19 @@
                   <GridPane>
                      <columnConstraints>
                         <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
                      </columnConstraints>
                      <rowConstraints>
                         <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
                      </rowConstraints>
                      <children>
-                                <Button fx:id="buttonStartStop" disable="true" mnemonicParsing="false" onAction="#handleButtonStartStop" prefHeight="32.0" prefWidth="100.0" text="Start Bot">
+                        <Button fx:id="buttonStartStop" disable="true" mnemonicParsing="false" onAction="#handleButtonStartStop" prefHeight="32.0" prefWidth="100.0" text="Start Bot">
                            <GridPane.margin>
-                              <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
+                              <Insets bottom="3.0" left="3.0" right="1.5" top="3.0" />
+                           </GridPane.margin></Button>
+                        <Button fx:id="buttonPauseResume" disable="true" mnemonicParsing="false" onAction="#handleButtonPauseResume" prefHeight="32.0" prefWidth="100.0" text="Pause Bot" GridPane.columnIndex="1">
+                           <GridPane.margin>
+                              <Insets bottom="3.0" left="1.5" right="3.0" top="3.0" />
                            </GridPane.margin></Button>
                      </children>
                   </GridPane>

--- a/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
@@ -72,6 +72,7 @@ public enum EnumConfigurationKey {
 	PET_SKILL_GATHERING_BOOL("false",Boolean.class),
 	PET_PERSONAL_TREASURE_BOOL("false",Boolean.class),
 	
+	GROWTH_SPEED_BOOL("false",Boolean.class),
 	
 	BOOL_BANK("false",Boolean.class),
 	INT_BANK_DELAY("1",Integer.class),

--- a/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
@@ -41,11 +41,11 @@ public enum EnumConfigurationKey {
 	GATHER_WOOD_BOOL("false",Boolean.class),
 	GATHER_MEAT_BOOL("false",Boolean.class),
 	GATHER_IRON_BOOL("false",Boolean.class),
-	
 	GATHER_COAL_LEVEL_INT("1",Integer.class),
 	GATHER_WOOD_LEVEL_INT("1",Integer.class),
 	GATHER_MEAT_LEVEL_INT("1",Integer.class),
 	GATHER_IRON_LEVEL_INT("1",Integer.class),
+	GATHER_ACTIVE_MARCH_QUEUE_INT("6",Integer.class),
 	
 	INTEL_BOOL("false",Boolean.class),
 	INTEL_FIRE_BEAST_BOOL("false",Boolean.class),

--- a/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
@@ -36,7 +36,7 @@ public enum EnumConfigurationKey {
 	ALLIANCE_HELP_REQUESTS_BOOL("false",Boolean.class),
 	ALLIANCE_HELP_REQUESTS_OFFSET_INT("1",Integer.class),
 	
-	
+	GATHER_SPEED_BOOL("false",Boolean.class),
 	GATHER_COAL_BOOL("false",Boolean.class),
 	GATHER_WOOD_BOOL("false",Boolean.class),
 	GATHER_MEAT_BOOL("false",Boolean.class),
@@ -71,8 +71,6 @@ public enum EnumConfigurationKey {
 	PET_SKILL_TRESURE_BOOL("false",Boolean.class),
 	PET_SKILL_GATHERING_BOOL("false",Boolean.class),
 	PET_PERSONAL_TREASURE_BOOL("false",Boolean.class),
-	
-	GROWTH_SPEED_BOOL("false",Boolean.class),
 	
 	BOOL_BANK("false",Boolean.class),
 	INT_BANK_DELAY("1",Integer.class),

--- a/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/TpDailyTaskEnum.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/TpDailyTaskEnum.java
@@ -23,6 +23,7 @@ public enum TpDailyTaskEnum {
 	PET_SKILL_TREASURE(18, "Pet Skill Treasure"),
 	PET_SKILL_GATHERING(19, "Pet Skill Gathering"),
 	
+	GROWTH_SPEED(20, "Growth Speed"),
 	
 	
 	MAIL_REWARDS(30, "Mail Rewards"),

--- a/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/TpDailyTaskEnum.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/TpDailyTaskEnum.java
@@ -23,8 +23,7 @@ public enum TpDailyTaskEnum {
 	PET_SKILL_TREASURE(18, "Pet Skill Treasure"),
 	PET_SKILL_GATHERING(19, "Pet Skill Gathering"),
 	
-	GROWTH_SPEED(20, "Growth Speed"),
-	
+	GATHER_SPEED(20, "Gather Speed Boost"),
 	
 	MAIL_REWARDS(30, "Mail Rewards"),
 	DAILY_TASKS(31, "Daily Tasks"),

--- a/wos-ot/src/main/java/cl/camodev/wosbot/ot/DTOBotState.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/ot/DTOBotState.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public class DTOBotState {
 
 	private Boolean running;
+	private Boolean paused;
 	private LocalDateTime actionTime;
 
 	public Boolean getRunning() {
@@ -13,6 +14,14 @@ public class DTOBotState {
 
 	public void setRunning(Boolean running) {
 		this.running = running;
+	}
+
+	public Boolean getPaused() {
+		return paused;
+	}
+
+	public void setPaused(Boolean paused) {
+		this.paused = paused;
 	}
 
 	public LocalDateTime getActionTime() {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -260,7 +260,9 @@ public class ServScheduler {
 
 				queueManager.startQueue(queueName);
 
-			});			listeners.forEach(e -> {
+			});
+			
+			listeners.forEach(e -> {
 				DTOBotState state = new DTOBotState();
 				state.setRunning(true);
 				state.setPaused(false);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -338,7 +338,7 @@ public class ServScheduler {
 
 	/**
 	 * Starts queues with a staggered delay to prevent profiles from starting simultaneously.
-	 * Each profile starts 10 seconds after the previous one to avoid synchronization issues
+	 * Each profile starts 3 seconds after the previous one to avoid synchronization issues
 	 * like multiple profiles marching to the same target.
 	 * 
 	 * @param profiles List of enabled profiles to start
@@ -351,12 +351,12 @@ public class ServScheduler {
 				
 				try {
 					if (i > 0) {
-						// Wait 10 seconds before starting the next profile (except for the first one)
-						Thread.sleep(10000);
+						// Wait 3 seconds before starting the next profile (except for the first one)
+						Thread.sleep(3000);
 					}
-					
-					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, "ServScheduler", queueName, 
-						"Starting queue" + (i > 0 ? " (delayed " + (i * 10) + " seconds)" : ""));
+
+					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, "ServScheduler", queueName,
+						"Starting queue" + (i > 0 ? " (delayed " + (i * 3) + " seconds)" : ""));
 					queueManager.startQueue(queueName);
 					
 				} catch (InterruptedException e) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -41,7 +41,7 @@ import cl.camodev.wosbot.serv.task.impl.DailyStaminaTask;
 import cl.camodev.wosbot.serv.task.impl.ExplorationTask;
 import cl.camodev.wosbot.serv.task.impl.GatherTask;
 import cl.camodev.wosbot.serv.task.impl.GatherTask.GatherType;
-import cl.camodev.wosbot.serv.task.impl.GrowthSpeedTask;
+import cl.camodev.wosbot.serv.task.impl.GatherSpeedTask;
 import cl.camodev.wosbot.serv.task.impl.HeroRecruitmentTask;
 import cl.camodev.wosbot.serv.task.impl.InitializeTask;
 import cl.camodev.wosbot.serv.task.impl.IntelligenceTask;
@@ -121,8 +121,8 @@ public class ServScheduler {
 				// Mapa de tareas con listas para manejar múltiples instancias de tareas bajo la misma clave
 				Map<EnumConfigurationKey, List<Supplier<DelayedTask>>> taskMappings = new HashMap<>();
 				
-				taskMappings.put(EnumConfigurationKey.GROWTH_SPEED_BOOL, List.of(
-					() -> new GrowthSpeedTask(profile, TpDailyTaskEnum.GROWTH_SPEED)
+				taskMappings.put(EnumConfigurationKey.GATHER_SPEED_BOOL, List.of(
+					() -> new GatherSpeedTask(profile, TpDailyTaskEnum.GATHER_SPEED)
 				));
 
 				// Agregar tareas al mapa
@@ -247,9 +247,9 @@ public class ServScheduler {
 							if (taskSchedules.containsKey(task.getTpDailyTaskId())) {
 								LocalDateTime nextSchedule = taskSchedules.get(task.getTpDailyTaskId()).getNextSchedule();
 								task.reschedule(nextSchedule);
-//								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Next Exceution in: " + UtilTime.localDateTimeToDDHHMMSS(nextSchedule));
+								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Next Exceution: " + nextSchedule);
 							} else {
-//								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Task not completed, scheduling for today");
+								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Task not completed, scheduling for today");
 								task.reschedule(LocalDateTime.now());
 							}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -254,11 +254,10 @@ public class ServScheduler {
 
 				queueManager.startQueue(queueName);
 
-			});
-
-			listeners.forEach(e -> {
+			});			listeners.forEach(e -> {
 				DTOBotState state = new DTOBotState();
 				state.setRunning(true);
+				state.setPaused(false);
 				state.setActionTime(LocalDateTime.now());
 				e.onBotStateChange(state);
 			});
@@ -274,7 +273,6 @@ public class ServScheduler {
 		}
 		listeners.add(listener);
 	}
-
 	public void stopBot() {
 		queueManager.stopQueues();
 
@@ -291,6 +289,51 @@ public class ServScheduler {
 		listeners.forEach(e -> {
 			DTOBotState state = new DTOBotState();
 			state.setRunning(false);
+			state.setPaused(false);
+			state.setActionTime(LocalDateTime.now());
+			e.onBotStateChange(state);
+		});
+	}
+
+	public void pauseBot() {
+		queueManager.pauseQueues();
+
+		List<DTOProfiles> profiles = ServProfiles.getServices().getProfiles();
+
+		if (profiles == null || profiles.isEmpty()) {
+			return;
+		}
+
+		profiles.stream().forEach(profile -> {
+			ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "PAUSED"));
+		});
+
+		listeners.forEach(e -> {
+			DTOBotState state = new DTOBotState();
+			state.setRunning(true);
+			state.setPaused(true);
+			state.setActionTime(LocalDateTime.now());
+			e.onBotStateChange(state);
+		});
+	}
+
+	public void resumeBot() {
+		queueManager.resumeQueues();
+
+		List<DTOProfiles> profiles = ServProfiles.getServices().getProfiles();
+
+		if (profiles == null || profiles.isEmpty()) {
+			return;
+		}
+
+		profiles.stream().forEach(profile -> {
+			ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "RUNNING"));
+		});
+
+		listeners.forEach(e -> {
+			DTOBotState state = new DTOBotState();
+			state.setRunning(true);
+			state.setPaused(false);
 			state.setActionTime(LocalDateTime.now());
 			e.onBotStateChange(state);
 		});

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -41,6 +41,7 @@ import cl.camodev.wosbot.serv.task.impl.DailyStaminaTask;
 import cl.camodev.wosbot.serv.task.impl.ExplorationTask;
 import cl.camodev.wosbot.serv.task.impl.GatherTask;
 import cl.camodev.wosbot.serv.task.impl.GatherTask.GatherType;
+import cl.camodev.wosbot.serv.task.impl.GrowthSpeedTask;
 import cl.camodev.wosbot.serv.task.impl.HeroRecruitmentTask;
 import cl.camodev.wosbot.serv.task.impl.InitializeTask;
 import cl.camodev.wosbot.serv.task.impl.IntelligenceTask;
@@ -119,6 +120,10 @@ public class ServScheduler {
 				//@formatter:off
 				// Mapa de tareas con listas para manejar múltiples instancias de tareas bajo la misma clave
 				Map<EnumConfigurationKey, List<Supplier<DelayedTask>>> taskMappings = new HashMap<>();
+				
+				taskMappings.put(EnumConfigurationKey.GROWTH_SPEED_BOOL, List.of(
+					() -> new GrowthSpeedTask(profile, TpDailyTaskEnum.GROWTH_SPEED)
+				));
 
 				// Agregar tareas al mapa
 				taskMappings.put(EnumConfigurationKey.BOOL_EXPLORATION_CHEST, List.of(
@@ -173,6 +178,7 @@ public class ServScheduler {
 				taskMappings.put(EnumConfigurationKey.PET_SKILL_GATHERING_BOOL, List.of(
 					() -> new PetSkillsTask(profile, TpDailyTaskEnum.PET_SKILL_GATHERING, PetSkill.GATHERING)
 				));
+				
 				
 				taskMappings.put(EnumConfigurationKey.PET_SKILL_STAMINA_BOOL, List.of(
 					() -> new PetSkillsTask(profile, TpDailyTaskEnum.PET_SKILL_STAMINA, PetSkill.STAMINA)

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -202,10 +202,6 @@ public class ServScheduler {
                         () -> new PetAdventureChestTask(profile, TpDailyTaskEnum.PET_ADVENTURE)
                     ));
 				
-				taskMappings.put(EnumConfigurationKey.INTEL_BOOL, List.of(
-                        () -> new IntelligenceTask(profile, TpDailyTaskEnum.INTEL)
-                    ));
-				
 				taskMappings.put(EnumConfigurationKey.GATHER_MEAT_BOOL, List.of(
                         () -> new GatherTask(profile, TpDailyTaskEnum.GATHER_RESOURCES, GatherType.MEAT)
                     ));
@@ -220,6 +216,10 @@ public class ServScheduler {
 				
 				taskMappings.put(EnumConfigurationKey.GATHER_IRON_BOOL, List.of(
                         () -> new GatherTask(profile, TpDailyTaskEnum.GATHER_RESOURCES, GatherType.IRON)
+                    ));
+				
+				taskMappings.put(EnumConfigurationKey.INTEL_BOOL, List.of(
+                        () -> new IntelligenceTask(profile, TpDailyTaskEnum.INTEL)
                     ));
 				
 				taskMappings.put(EnumConfigurationKey.LIFE_ESSENCE_BOOL, List.of(

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueueManager.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueueManager.java
@@ -28,10 +28,21 @@ public class TaskQueueManager {
 			queue.start();
 		}
 	}
-
 	public void stopQueues() {
 		taskQueues.forEach((k, v) -> {
 			v.stop();
+		});
+	}
+
+	public void pauseQueues() {
+		taskQueues.forEach((k, v) -> {
+			v.pause();
+		});
+	}
+
+	public void resumeQueues() {
+		taskQueues.forEach((k, v) -> {
+			v.resume();
 		});
 	}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceAutojoinTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceAutojoinTask.java
@@ -11,6 +11,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class AllianceAutojoinTask extends DelayedTask {
@@ -62,7 +63,10 @@ public class AllianceAutojoinTask extends DelayedTask {
 
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(380, 1070), new DTOPoint(640, 1120));
 
-		this.reschedule(LocalDateTime.now().plusHours(7));
+		LocalDateTime nextSchedule = LocalDateTime.now().plusHours(7);
+		this.reschedule(nextSchedule);
+		ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
+
 		emulator.tapBackButton(EMULATOR_NUMBER);
 		emulator.tapBackButton(EMULATOR_NUMBER);
 		emulator.tapBackButton(EMULATOR_NUMBER);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTask.java
@@ -47,22 +47,22 @@ public class AllianceChestTask extends DelayedTask {
 		}
 
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, allianceChestResult.getPoint(), allianceChestResult.getPoint());
-		sleepTask(4000);
+		sleepTask(500);
 
 		// Abrir el cofre
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(56, 375), new DTOPoint(320, 420));
-		sleepTask(2000);
+		sleepTask(500);
 
 		// Buscar el botón de reclamar recompensas
 		DTOImageSearchResult claimButton = emulator.searchTemplate(EMULATOR_NUMBER, EnumTemplates.ALLIANCE_CHEST_LOOT_CLAIM_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 		if (claimButton.isFound()) {
 			emulator.tapAtRandomPoint(EMULATOR_NUMBER, claimButton.getPoint(), claimButton.getPoint(), 10, 300);
-			sleepTask(1000);
+			sleepTask(500);
 		}
 
 		// Confirmar la acción
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(410, 375), new DTOPoint(626, 420));
-		sleepTask(2000);
+		sleepTask(500);
 
 		// Cerrar la ventana
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(578, 1180), new DTOPoint(641, 1200), 10, 300);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceHelpTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceHelpTask.java
@@ -49,7 +49,7 @@ public class AllianceHelpTask extends DelayedTask {
 		logs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Alliance help button found");
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, allianceChestResult.getPoint(), allianceChestResult.getPoint());
 
-		sleepTask(2000);
+		sleepTask(500);
 
 		DTOImageSearchResult allianceHelpResult = emulator.searchTemplate(EMULATOR_NUMBER, EnumTemplates.ALLIANCE_HELP_REQUESTS.getTemplate(), 0, 0, 720, 1280, 90);
 		if (allianceHelpResult.isFound()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceTechTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceTechTask.java
@@ -11,6 +11,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class AllianceTechTask extends DelayedTask {
@@ -66,7 +67,10 @@ public class AllianceTechTask extends DelayedTask {
 		emulator.tapBackButton(EMULATOR_NUMBER);
 		emulator.tapBackButton(EMULATOR_NUMBER);
 		emulator.tapBackButton(EMULATOR_NUMBER);
-		this.reschedule(LocalDateTime.now().plusHours(profile.getConfig(EnumConfigurationKey.ALLIANCE_TECH_OFFSET_INT, Integer.class)));
+		
+		LocalDateTime nextSchedule = LocalDateTime.now().plusHours(profile.getConfig(EnumConfigurationKey.ALLIANCE_TECH_OFFSET_INT, Integer.class));
+		this.reschedule(nextSchedule);
+		ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
 
 	}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceTechTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceTechTask.java
@@ -48,7 +48,7 @@ public class AllianceTechTask extends DelayedTask {
 		}
 
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, menuResult.getPoint(), menuResult.getPoint());
-		sleepTask(4000);
+		sleepTask(500);
 
 		// search for thumb up button
 
@@ -61,7 +61,7 @@ public class AllianceTechTask extends DelayedTask {
 
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, thumbUpResult.getPoint(), thumbUpResult.getPoint());
 
-		sleepTask(2000);
+		sleepTask(500);
 
 		emulator.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(450, 1000), new DTOPoint(580, 1050), 25, 100);
 		emulator.tapBackButton(EMULATOR_NUMBER);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BankTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BankTask.java
@@ -14,6 +14,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 import net.sourceforge.tess4j.TesseractException;
 
@@ -74,7 +75,7 @@ public class BankTask extends DelayedTask {
 					emulatorManager.executeSwipe(EMULATOR_NUMBER, new DTOPoint(168, 762), new DTOPoint(477, 760));
 					emulatorManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(410, 877), new DTOPoint(589, 919));
 
-					reschedule(LocalDateTime.now().plusDays(bankDelay));
+					this.reschedule(LocalDateTime.now().plusDays(bankDelay));
 					emulatorManager.tapBackButton(EMULATOR_NUMBER);
 					return;
 				}
@@ -83,7 +84,8 @@ public class BankTask extends DelayedTask {
 				try {
 					String timeLeft = emulatorManager.ocrRegionText(EMULATOR_NUMBER, new DTOPoint(100, 585), new DTOPoint(290, 614));
 					LocalDateTime nextBank = parseAndAddToNow(timeLeft);
-					reschedule(nextBank);
+					this.reschedule(nextBank);
+					ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextBank);
 					return;
 				} catch (IOException | TesseractException e) {
 					ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, taskName, profile.getName(), "Error al procesar OCR del tiempo restante");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BeastSlayTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BeastSlayTask.java
@@ -17,6 +17,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 import net.sourceforge.tess4j.TesseractException;
 
@@ -66,6 +67,7 @@ public class BeastSlayTask extends DelayedTask {
 					LocalDateTime fullStaminaTime = calculateFullStaminaTime(stamina, 100, 5);
 //					servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Stamina is less than 10, rescheduling to " + UtilTime.localDateTimeToDDHHMMSS(fullStaminaTime));
 					this.reschedule(fullStaminaTime);
+					ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, fullStaminaTime);
 					return;
 				}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DailyStaminaTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DailyStaminaTask.java
@@ -35,10 +35,10 @@ public class DailyStaminaTask extends DelayedTask {
 			}
 
 			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(3, 513), new DTOPoint(26, 588));
-			sleepTask(2000);
+			sleepTask(1000);
 
 			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(20, 250), new DTOPoint(200, 280));
-			sleepTask(2000);
+			sleepTask(500);
 
 			DTOImageSearchResult researchCenter = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_SHORTCUTS_RESEARCH_CENTER.getTemplate(), 0, 0, 720, 1280, 90);
 
@@ -47,7 +47,7 @@ public class DailyStaminaTask extends DelayedTask {
 					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, researchCenter.getPoint(), researchCenter.getPoint());
 					sleepTask(2000);
 					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(30, 430), new DTOPoint(50, 470));
-					sleepTask(2000);
+					sleepTask(500);
 
 					DTOImageSearchResult chest = null;
 					System.out.println("Searching for chest");
@@ -60,7 +60,7 @@ public class DailyStaminaTask extends DelayedTask {
 							System.out.println("Chest found, tapping");
 							servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Claiming chest");
 							emuManager.tapAtRandomPoint(EMULATOR_NUMBER, chest.getPoint(), chest.getPoint());
-							sleepTask(2000);
+							sleepTask(500);
 
 							emuManager.tapBackButton(EMULATOR_NUMBER);
 							for (int j = 0; j < 5; j++) {
@@ -69,9 +69,9 @@ public class DailyStaminaTask extends DelayedTask {
 								if (stamina.isFound()) {
 									servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Claiming stamina");
 									emuManager.tapAtRandomPoint(EMULATOR_NUMBER, stamina.getPoint(), stamina.getPoint());
-									sleepTask(2000);
+									sleepTask(500);
 									emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(250, 930), new DTOPoint(450, 950));
-									sleepTask(6000);
+									sleepTask(500);
 									break;
 								} else {
 									System.out.println("Stamina not found, sleeping");
@@ -96,9 +96,9 @@ public class DailyStaminaTask extends DelayedTask {
 							if (stamina.isFound()) {
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Claiming stamina");
 								emuManager.tapAtRandomPoint(EMULATOR_NUMBER, stamina.getPoint(), stamina.getPoint());
-								sleepTask(2000);
+								sleepTask(500);
 								emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(250, 930), new DTOPoint(450, 950));
-								sleepTask(6000);
+								sleepTask(500);
 								break;
 							} else {
 								System.out.println("Stamina not found, sleeping");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExplorationTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExplorationTask.java
@@ -29,14 +29,14 @@ public class ExplorationTask extends DelayedTask {
 		if (homeResult.isFound() || worldResult.isFound()) {
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "going to exploration");
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(40, 1190), new DTOPoint(100, 1250));
-			sleepTask(3000);
+			sleepTask(500);
 			DTOImageSearchResult claimResult = EmulatorManager.getInstance().searchTemplate(EMULATOR_NUMBER, EnumTemplates.EXPLORATION_CLAIM.getTemplate(), 0, 0, 720, 1280, 95);
 			if (claimResult.isFound()) {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "claiming rewards");
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(560, 900), new DTOPoint(670, 940));
-				sleepTask(3000);
+				sleepTask(500);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(230, 890), new DTOPoint(490, 960));
-				sleepTask(3000);
+				sleepTask(500);
 
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(230, 890), new DTOPoint(490, 960));
 				sleepTask(200);
@@ -64,7 +64,7 @@ public class ExplorationTask extends DelayedTask {
 			EmulatorManager.getInstance().tapBackButton(EMULATOR_NUMBER);
 
 		}
-		sleepTask(3000);
+		sleepTask(500);
 
 	}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExplorationTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExplorationTask.java
@@ -11,6 +11,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class ExplorationTask extends DelayedTask {
@@ -45,11 +46,15 @@ public class ExplorationTask extends DelayedTask {
 				sleepTask(200);
 
 				int offset = profile.getConfig(EnumConfigurationKey.INT_EXPLORATION_CHEST_OFFSET, Integer.class);
-				this.reschedule(LocalDateTime.now().plusHours(offset));
+				LocalDateTime nextSchedule = LocalDateTime.now().plusHours(offset);
+				this.reschedule(nextSchedule);
+				ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
 
 			} else {
 				int offset = profile.getConfig(EnumConfigurationKey.INT_EXPLORATION_CHEST_OFFSET, Integer.class);
-				this.reschedule(LocalDateTime.now().plusHours(offset));
+				LocalDateTime nextSchedule = LocalDateTime.now().plusHours(offset);
+				this.reschedule(nextSchedule);
+				ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "no rewards to claim");
 			}
 			EmulatorManager.getInstance().tapBackButton(EMULATOR_NUMBER);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherSpeedTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherSpeedTask.java
@@ -10,14 +10,15 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 
-public class GrowthSpeedTask extends DelayedTask {
+public class GatherSpeedTask extends DelayedTask {
 
     private final EmulatorManager emuManager = EmulatorManager.getInstance();
     private final ServLogs servLogs = ServLogs.getServices();
 
-    public GrowthSpeedTask(DTOProfiles profile, TpDailyTaskEnum tpTask) {
+    public GatherSpeedTask(DTOProfiles profile, TpDailyTaskEnum tpTask) {
         super(profile, tpTask);
     }
 
@@ -29,49 +30,52 @@ public class GrowthSpeedTask extends DelayedTask {
         if (homeResult.isFound() || worldResult.isFound()) {
             if (worldResult.isFound()) {
                 emuManager.tapAtPoint(EMULATOR_NUMBER, worldResult.getPoint());
-                sleepTask(4000);
+                sleepTask(3000);
             }
 
-            servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Starting growth speed boost");
+            servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Starting gather speed boost");
 
             // Click the small icon under the profile picture
-            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(18, 61));
-            sleepTask(500);
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(40, 118));
+            sleepTask(1000);
 
-            // Click growth tab
-            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(284, 60));
-            sleepTask(500);
+            // Click gather tab
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(530, 122));
+            sleepTask(1000);
 
             // Click gathering speed button
-            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(349, 215));
-            sleepTask(500);
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(313, 406));
+            sleepTask(1000);
 
             // Click use button
-            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(311, 295));
-            sleepTask(500);
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(578, 568));
+            sleepTask(1000);
 
             // Click buy button
-            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(306, 204));
-            sleepTask(500);
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(585, 391));
+            sleepTask(1000);
 
             // Click confirm buy button
-            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(200, 415));
-            sleepTask(500);
-
-            servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Growth speed boost completed");
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(382, 784));
+            sleepTask(1000);
+            
+            servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Gather speed boost completed");
 
             // Reschedule task for 8 hours later
-            this.reschedule(LocalDateTime.now().plusHours(8));
+            LocalDateTime nextSchedule = LocalDateTime.now().plusHours(8);
+            this.reschedule(nextSchedule);
+            ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
 
             // Go back to home
             emuManager.tapBackButton(EMULATOR_NUMBER);
             emuManager.tapBackButton(EMULATOR_NUMBER);
             emuManager.tapBackButton(EMULATOR_NUMBER);
-
         } else {
             servLogs.appendLog(EnumTpMessageSeverity.WARNING, taskName, profile.getName(), "Home not found");
             emuManager.tapBackButton(EMULATOR_NUMBER);
-            this.reschedule(LocalDateTime.now().plusMinutes(5));
+
+            LocalDateTime retrySchedule = LocalDateTime.now().plusMinutes(5);
+            this.reschedule(retrySchedule);
         }
     }
 }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherSpeedTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherSpeedTask.java
@@ -37,27 +37,27 @@ public class GatherSpeedTask extends DelayedTask {
 
             // Click the small icon under the profile picture
             emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(40, 118));
-            sleepTask(1000);
+            sleepTask(500);
 
             // Click gather tab
             emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(530, 122));
-            sleepTask(1000);
+            sleepTask(500);
 
             // Click gathering speed button
             emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(313, 406));
-            sleepTask(1000);
+            sleepTask(500);
 
             // Click use button
             emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(578, 568));
-            sleepTask(1000);
+            sleepTask(500);
 
             // Click buy button
             emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(585, 391));
-            sleepTask(1000);
+            sleepTask(500);
 
             // Click confirm buy button
             emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(382, 784));
-            sleepTask(1000);
+            sleepTask(500);
             
             servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Gather speed boost completed");
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -181,7 +181,7 @@ public class GatherTask extends DelayedTask {
 							if (march.isFound()) {
 								emuManager.tapBackButton(EMULATOR_NUMBER);
 								emuManager.tapBackButton(EMULATOR_NUMBER);
-								reschedule(LocalDateTime.now().plusMinutes(5));
+								reschedule(LocalDateTime.now());
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "March already gathering");
 							} else {
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "March started");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -146,15 +146,15 @@ public class GatherTask extends DelayedTask {
 					DTOImageSearchResult gather = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_SHORTCUTS_FARM_GATHER.getTemplate(), 0, 0, 720, 1280, 90);
 					if (gather.isFound()) {
 						emuManager.tapAtPoint(EMULATOR_NUMBER, gather.getPoint());
-						sleepTask(3000);
+						sleepTask(500);
 
 						// verificar el heroe y remover restantes
 						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(171, 430));
-						sleepTask(1000);
+						sleepTask(500);
 						// remover restantes
 						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(560, 348));
 
-						sleepTask(1000);
+						sleepTask(500);
 						DTOImageSearchResult remove = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_REMOVE_HERO_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (remove.isFound()) {
 							emuManager.tapAtPoint(EMULATOR_NUMBER, remove.getPoint());
@@ -166,7 +166,7 @@ public class GatherTask extends DelayedTask {
 						remove = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_REMOVE_HERO_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (remove.isFound()) {
 							emuManager.tapAtPoint(EMULATOR_NUMBER, remove.getPoint());
-							sleepTask(1000);
+							sleepTask(500);
 						}
 						emuManager.tapBackButton(EMULATOR_NUMBER);
 						// falta fverificar si esta el heroe adecuado
@@ -175,7 +175,7 @@ public class GatherTask extends DelayedTask {
 						DTOImageSearchResult gatherButton = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_GATHER_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (gatherButton.isFound()) {
 							emuManager.tapAtPoint(EMULATOR_NUMBER, gatherButton.getPoint());
-							sleepTask(3000);
+							sleepTask(500);
 							// verificar si ya hay un marcha en curso
 							DTOImageSearchResult march = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_GATHER_ALREADY_MARCHING.getTemplate(), 0, 0, 720, 1280, 90);
 							if (march.isFound()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -82,9 +82,9 @@ public class GatherTask extends DelayedTask {
 
 			// verificar marchas activas
 			emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(2, 550));
-			sleepTask(1000);
+			sleepTask(500);
 			emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(340, 265));
-			sleepTask(1000);
+			sleepTask(500);
 			servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "looking for " + gatherType);
 			
 			// Get active march queue setting and calculate search region
@@ -114,7 +114,7 @@ public class GatherTask extends DelayedTask {
 				homeResult = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_FURNACE.getTemplate(), 0, 0, 720, 1280, 90);
 				if (homeResult.isFound()) {
 					emuManager.tapAtPoint(EMULATOR_NUMBER, homeResult.getPoint());
-					sleepTask(4000);
+					sleepTask(3000);
 				}
 				// debo mandar un escuadro a recojer recursos
 				// ir a la lupa
@@ -129,7 +129,7 @@ public class GatherTask extends DelayedTask {
 				if (tile.isFound()) {
 					emuManager.tapAtPoint(EMULATOR_NUMBER, tile.getPoint());
 					// regresar al nivel 1
-					sleepTask(1000);
+					sleepTask(500);
 					emuManager.executeSwipe(EMULATOR_NUMBER, new DTOPoint(435, 1052), new DTOPoint(40, 1052));
 					sleepTask(300);
 					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(487, 1055), new DTOPoint(487, 1055), (profile.getConfig(gatherType.getConfig(), Integer.class) - 1), 50);
@@ -152,32 +152,32 @@ public class GatherTask extends DelayedTask {
 
 						// verificar el heroe y remover restantes
 						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(171, 430));
-						sleepTask(500);
+						sleepTask(200);
 						// remover restantes
 						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(560, 348));
 
-						sleepTask(500);
+						sleepTask(200);
 						DTOImageSearchResult remove = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_REMOVE_HERO_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (remove.isFound()) {
 							emuManager.tapAtPoint(EMULATOR_NUMBER, remove.getPoint());
-							sleepTask(500);
+							sleepTask(200);
 						}
 
 						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(362, 348));
-						sleepTask(500);
+						sleepTask(200);
 						remove = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_REMOVE_HERO_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (remove.isFound()) {
 							emuManager.tapAtPoint(EMULATOR_NUMBER, remove.getPoint());
-							sleepTask(500);
+							sleepTask(200);
 						}
 						emuManager.tapBackButton(EMULATOR_NUMBER);
 						// falta fverificar si esta el heroe adecuado
-						sleepTask(500);
+						sleepTask(200);
 						// click gather
 						DTOImageSearchResult gatherButton = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_GATHER_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (gatherButton.isFound()) {
 							emuManager.tapAtPoint(EMULATOR_NUMBER, gatherButton.getPoint());
-							sleepTask(500);
+							sleepTask(200);
 							// verificar si ya hay un marcha en curso
 							DTOImageSearchResult march = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_GATHER_ALREADY_MARCHING.getTemplate(), 0, 0, 720, 1280, 90);
 							if (march.isFound()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -182,7 +182,7 @@ public class GatherTask extends DelayedTask {
 							if (march.isFound()) {
 								emuManager.tapBackButton(EMULATOR_NUMBER);
 								emuManager.tapBackButton(EMULATOR_NUMBER);
-								reschedule(LocalDateTime.now().plusMinutes(5));
+								reschedule(LocalDateTime.now());
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "March already gathering");
 							} else {
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "March started");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -99,7 +99,9 @@ public class GatherTask extends DelayedTask {
 				if (index != -1) {
 					try {
 						String time = emuManager.ocrRegionText(EMULATOR_NUMBER, queues[index][2], new DTOPoint(queues[index][2].getX() + 140, queues[index][2].getY() + 19));
-						this.reschedule(parseRemaining(time).plusMinutes(5));
+						LocalDateTime nextSchedule = parseRemaining(time).plusMinutes(5);
+						this.reschedule(nextSchedule);
+						servScheduler.updateDailyTaskStatus(profile, tpTask, nextSchedule);
 					} catch (Exception e) {
 
 					}

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -167,6 +167,11 @@ public class GatherTask extends DelayedTask {
 						emuManager.tapBackButton(EMULATOR_NUMBER);
 						// falta fverificar si esta el heroe adecuado
 						sleepTask(500);
+
+						// click equalize
+						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(195, 1190));
+						sleepTask(500);
+
 						// click gather
 						DTOImageSearchResult gatherButton = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_GATHER_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (gatherButton.isFound()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -167,11 +167,6 @@ public class GatherTask extends DelayedTask {
 						emuManager.tapBackButton(EMULATOR_NUMBER);
 						// falta fverificar si esta el heroe adecuado
 						sleepTask(500);
-
-						// click equalize
-						emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(195, 1190));
-						sleepTask(500);
-
 						// click gather
 						DTOImageSearchResult gatherButton = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.RALLY_GATHER_BUTTON.getTemplate(), 0, 0, 720, 1280, 90);
 						if (gatherButton.isFound()) {
@@ -182,7 +177,7 @@ public class GatherTask extends DelayedTask {
 							if (march.isFound()) {
 								emuManager.tapBackButton(EMULATOR_NUMBER);
 								emuManager.tapBackButton(EMULATOR_NUMBER);
-								reschedule(LocalDateTime.now());
+								reschedule(LocalDateTime.now().plusMinutes(5));
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "March already gathering");
 							} else {
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "March started");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -83,11 +83,15 @@ public class GatherTask extends DelayedTask {
 			// verificar marchas activas
 			emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(2, 550));
 			sleepTask(1000);
-
 			emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(340, 265));
 			sleepTask(1000);
 			servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "looking for " + gatherType);
-			DTOImageSearchResult resource = emuManager.searchTemplate(EMULATOR_NUMBER, gatherType.getTemplate(), 10, 342, (425 - 10), 772, 90);
+			
+			// Get active march queue setting and calculate search region
+			int activeMarchQueues = profile.getConfig(EnumConfigurationKey.GATHER_ACTIVE_MARCH_QUEUE_INT, Integer.class);
+			int maxY = queues[Math.min(activeMarchQueues - 1, queues.length - 1)][1].getY(); // Use the Y coordinate of the last active queue
+			
+			DTOImageSearchResult resource = emuManager.searchTemplate(EMULATOR_NUMBER, gatherType.getTemplate(), 10, 342, (425 - 10), maxY, 90);
 
 			if (resource.isFound()) {
 				servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Resource found, getting remaining time");
@@ -204,9 +208,12 @@ public class GatherTask extends DelayedTask {
 		}
 
 	}
-
 	public int obtenerIndice(DTOPoint punto) {
-		for (int i = 0; i < queues.length; i++) {
+		// Get active march queue setting and limit the search to only active queues
+		int activeMarchQueues = profile.getConfig(EnumConfigurationKey.GATHER_ACTIVE_MARCH_QUEUE_INT, Integer.class);
+		int maxQueues = Math.min(activeMarchQueues, queues.length);
+		
+		for (int i = 0; i < maxQueues; i++) {
 			// Obtener los límites del rango (para asegurar el orden correcto, usamos Math.min y Math.max)
 			int minX = Math.min(queues[i][0].getX(), queues[i][1].getX());
 			int maxX = Math.max(queues[i][0].getX(), queues[i][1].getX());

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GrowthSpeedTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GrowthSpeedTask.java
@@ -1,0 +1,77 @@
+package cl.camodev.wosbot.serv.task.impl;
+
+import java.time.LocalDateTime;
+
+import cl.camodev.wosbot.console.enumerable.EnumTemplates;
+import cl.camodev.wosbot.console.enumerable.EnumTpMessageSeverity;
+import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
+import cl.camodev.wosbot.emulator.EmulatorManager;
+import cl.camodev.wosbot.ot.DTOImageSearchResult;
+import cl.camodev.wosbot.ot.DTOPoint;
+import cl.camodev.wosbot.ot.DTOProfiles;
+import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.task.DelayedTask;
+
+public class GrowthSpeedTask extends DelayedTask {
+
+    private final EmulatorManager emuManager = EmulatorManager.getInstance();
+    private final ServLogs servLogs = ServLogs.getServices();
+
+    public GrowthSpeedTask(DTOProfiles profile, TpDailyTaskEnum tpTask) {
+        super(profile, tpTask);
+    }
+
+    @Override
+    protected void execute() {
+        DTOImageSearchResult homeResult = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_FURNACE.getTemplate(), 0, 0, 720, 1280, 90);
+        DTOImageSearchResult worldResult = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_WORLD.getTemplate(), 0, 0, 720, 1280, 90);
+
+        if (homeResult.isFound() || worldResult.isFound()) {
+            if (worldResult.isFound()) {
+                emuManager.tapAtPoint(EMULATOR_NUMBER, worldResult.getPoint());
+                sleepTask(4000);
+            }
+
+            servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Starting growth speed boost");
+
+            // Click the small icon under the profile picture
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(18, 61));
+            sleepTask(500);
+
+            // Click growth tab
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(284, 60));
+            sleepTask(500);
+
+            // Click gathering speed button
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(349, 215));
+            sleepTask(500);
+
+            // Click use button
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(311, 295));
+            sleepTask(500);
+
+            // Click buy button
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(306, 204));
+            sleepTask(500);
+
+            // Click confirm buy button
+            emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(200, 415));
+            sleepTask(500);
+
+            servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Growth speed boost completed");
+
+            // Reschedule task for 8 hours later
+            this.reschedule(LocalDateTime.now().plusHours(8));
+
+            // Go back to home
+            emuManager.tapBackButton(EMULATOR_NUMBER);
+            emuManager.tapBackButton(EMULATOR_NUMBER);
+            emuManager.tapBackButton(EMULATOR_NUMBER);
+
+        } else {
+            servLogs.appendLog(EnumTpMessageSeverity.WARNING, taskName, profile.getName(), "Home not found");
+            emuManager.tapBackButton(EMULATOR_NUMBER);
+            this.reschedule(LocalDateTime.now().plusMinutes(5));
+        }
+    }
+}

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/HeroRecruitmentTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/HeroRecruitmentTask.java
@@ -36,9 +36,9 @@ public class HeroRecruitmentTask extends DelayedTask {
 		if (homeResult.isFound() || worldResult.isFound()) {
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "going hero recruitment");
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(160, 1190), new DTOPoint(217, 1250));
-			sleepTask(3000);
+			sleepTask(500);
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(400, 1190), new DTOPoint(660, 1250));
-			sleepTask(3000);
+			sleepTask(500);
 
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "evaluating advanced recruitment");
 			DTOImageSearchResult claimResult = EmulatorManager.getInstance().searchTemplate(EMULATOR_NUMBER, EnumTemplates.HERO_RECRUIT_CLAIM.getTemplate(), 40, 800, 300, 95, 95);
@@ -46,7 +46,7 @@ public class HeroRecruitmentTask extends DelayedTask {
 			if (claimResult.isFound()) {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "advanced recruitment available, tapping");
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 827), new DTOPoint(315, 875));
-				sleepTask(3000);
+				sleepTask(500);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
 				sleepTask(300);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
@@ -56,7 +56,7 @@ public class HeroRecruitmentTask extends DelayedTask {
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
 				sleepTask(300);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
-				sleepTask(3000);
+				sleepTask(1000);
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "getting next recruitment time");
 				String text = "";
 				try {
@@ -89,7 +89,7 @@ public class HeroRecruitmentTask extends DelayedTask {
 			if (claimResultEpic.isFound()) {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "epic recruitment available, tapping");
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(70, 1180), new DTOPoint(315, 1230));
-				sleepTask(3000);
+				sleepTask(500);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
 				sleepTask(300);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
@@ -99,7 +99,7 @@ public class HeroRecruitmentTask extends DelayedTask {
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
 				sleepTask(300);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(80, 90), new DTOPoint(140, 130));
-				sleepTask(3000);
+				sleepTask(1000);
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "getting next recruitment time");
 				String text = "";
 				try {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/InitializeTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/InitializeTask.java
@@ -42,7 +42,7 @@ public class InitializeTask extends DelayedTask {
 
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "launching game");
 			EmulatorManager.getInstance().launchApp(EMULATOR_NUMBER, EmulatorManager.WHITEOUT_PACKAGE);
-			sleepTask(25000);
+			sleepTask(15000);
 
 			boolean homeScreen = false;
 			int attempts = 0;

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
@@ -154,24 +154,20 @@ public class IntelligenceTask extends DelayedTask {
 				}
 			}
 
-			if (intelligence.isFound()) {
-				sleepTask(1000);
-				emuManager.tapAtPoint(EMULATOR_NUMBER, intelligence.getPoint());
-				sleepTask(500);
-				if(intelFound == false) {
-					try {
-						String rescheduleTime = emuManager.ocrRegionText(EMULATOR_NUMBER, new DTOPoint(120, 110), new DTOPoint(600, 146));
-						LocalDateTime reshchedule = parseAndAddTime(rescheduleTime);
-						this.reschedule(reshchedule);
-						emuManager.tapBackButton(EMULATOR_NUMBER);
-						ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, reshchedule);
-					} catch (IOException | TesseractException e) {
-						this.reschedule(LocalDateTime.now());
-						e.printStackTrace();
-					}
-				} else {
+			sleepTask(1000);
+			if(intelFound == false) {
+				try {
+					String rescheduleTime = emuManager.ocrRegionText(EMULATOR_NUMBER, new DTOPoint(120, 110), new DTOPoint(600, 146));
+					LocalDateTime reshchedule = parseAndAddTime(rescheduleTime);
+					this.reschedule(reshchedule);
+					emuManager.tapBackButton(EMULATOR_NUMBER);
+					ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, reshchedule);
+				} catch (IOException | TesseractException e) {
 					this.reschedule(LocalDateTime.now());
+					e.printStackTrace();
 				}
+			} else {
+				this.reschedule(LocalDateTime.now());
 			}
 
 		} else {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
@@ -22,6 +22,7 @@ import cl.camodev.wosbot.serv.task.DelayedTask;
 import net.sourceforge.tess4j.TesseractException;
 
 public class IntelligenceTask extends DelayedTask {
+	boolean intelFound = false;
 
 	private final EmulatorManager emuManager = EmulatorManager.getInstance();
 
@@ -59,12 +60,16 @@ public class IntelligenceTask extends DelayedTask {
 				if (profile.getConfig(EnumConfigurationKey.INTEL_FIRE_BEAST_BOOL, Boolean.class)) {
 					servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Searching for fire beasts");
 					if (searchAndProcessBeast(EnumTemplates.INTEL_FIRE_BEAST, 5)) {
-						this.reschedule(LocalDateTime.now().plusMinutes(3));
-						return;
+						//this.reschedule(LocalDateTime.now());
+						//return;
+						intelFound = true;
 					}
-
 				}
+			}
 
+			if (intelligence.isFound()) {
+				sleepTask(1000);
+				emuManager.tapAtPoint(EMULATOR_NUMBER, intelligence.getPoint());
 				if (profile.getConfig(EnumConfigurationKey.INTEL_BEASTS_BOOL, Boolean.class)) {
 					// @formatter:off
 					List<EnumTemplates> beastPriorities = Arrays.asList(
@@ -82,12 +87,18 @@ public class IntelligenceTask extends DelayedTask {
 					servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Searching for beasts");
 					for (EnumTemplates beast : beastPriorities) {
 						if (searchAndProcessBeast(beast, 5)) {
-							this.reschedule(LocalDateTime.now().plusMinutes(3));
-							return;
+							//this.reschedule(LocalDateTime.now());
+							//return;
+							intelFound = true;
+							sleepTask(500);
 						}
 					}
 				}
+			}
 
+			if (intelligence.isFound()) {
+				sleepTask(1000);
+				emuManager.tapAtPoint(EMULATOR_NUMBER, intelligence.getPoint());
 				if (profile.getConfig(EnumConfigurationKey.INTEL_CAMP_BOOL, Boolean.class)) {
 					// @formatter:off
 					List<EnumTemplates> priorities = Arrays.asList(
@@ -105,13 +116,18 @@ public class IntelligenceTask extends DelayedTask {
 					servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Searching for survivors");
 					for (EnumTemplates beast : priorities) {
 						if (searchAndProcessSurvivor(beast, 5)) {
-							this.reschedule(LocalDateTime.now());
-							return;
+							//this.reschedule(LocalDateTime.now());
+							//return;
+							intelFound = true;
 						}
 					}
 
 				}
+			}
 
+			if (intelligence.isFound()) {
+				sleepTask(1000);
+				emuManager.tapAtPoint(EMULATOR_NUMBER, intelligence.getPoint());
 				if (profile.getConfig(EnumConfigurationKey.INTEL_EXPLORATION_BOOL, Boolean.class)) {
 					// @formatter:off
 					List<EnumTemplates> priorities = Arrays.asList(
@@ -129,24 +145,33 @@ public class IntelligenceTask extends DelayedTask {
 					servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Searching for explorations");
 					for (EnumTemplates beast : priorities) {
 						if (searchAndProcessExploration(beast, 5)) {
-							this.reschedule(LocalDateTime.now());
-							return;
+							//this.reschedule(LocalDateTime.now());
+							//return;
+							intelFound = true;
 						}
 					}
 
 				}
+			}
 
-				try {
-					String rescheduleTime = emuManager.ocrRegionText(EMULATOR_NUMBER, new DTOPoint(120, 110), new DTOPoint(600, 146));
-					LocalDateTime reshchedule = parseAndAddTime(rescheduleTime);
-					this.reschedule(reshchedule);
-					emuManager.tapBackButton(EMULATOR_NUMBER);
-					ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, reshchedule);
-				} catch (IOException | TesseractException e) {
+			if (intelligence.isFound()) {
+				sleepTask(1000);
+				emuManager.tapAtPoint(EMULATOR_NUMBER, intelligence.getPoint());
+				sleepTask(500);
+				if(intelFound == false) {
+					try {
+						String rescheduleTime = emuManager.ocrRegionText(EMULATOR_NUMBER, new DTOPoint(120, 110), new DTOPoint(600, 146));
+						LocalDateTime reshchedule = parseAndAddTime(rescheduleTime);
+						this.reschedule(reshchedule);
+						emuManager.tapBackButton(EMULATOR_NUMBER);
+						ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, reshchedule);
+					} catch (IOException | TesseractException e) {
+						this.reschedule(LocalDateTime.now());
+						e.printStackTrace();
+					}
+				} else {
 					this.reschedule(LocalDateTime.now());
-					e.printStackTrace();
 				}
-
 			}
 
 		} else {
@@ -249,6 +274,8 @@ public class IntelligenceTask extends DelayedTask {
 			DTOImageSearchResult attack = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_ATTACK.getTemplate(), 0, 0, 720, 1280, 90);
 			if (attack.isFound()) {
 				emuManager.tapAtPoint(EMULATOR_NUMBER, attack.getPoint());
+				sleepTask(500);
+				emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(198, 1188)); // Click equalize
 				sleepTask(500);
 				DTOImageSearchResult rally = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_ATTACK_CONFIRM.getTemplate(), 0, 0, 720, 1280, 90);
 				if (rally.isFound()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
@@ -173,18 +173,18 @@ public class IntelligenceTask extends DelayedTask {
 
 	private void processJourney(DTOImageSearchResult result) {
 		emuManager.tapAtPoint(EMULATOR_NUMBER, result.getPoint());
-		sleepTask(3000);
+		sleepTask(2000);
 
 		DTOImageSearchResult view = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_VIEW.getTemplate(), 0, 0, 720, 1280, 90);
 		if (view.isFound()) {
 			emuManager.tapAtPoint(EMULATOR_NUMBER, view.getPoint());
-			sleepTask(3000);
+			sleepTask(500);
 			DTOImageSearchResult explore = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_EXPLORE.getTemplate(), 0, 0, 720, 1280, 90);
 			if (explore.isFound()) {
 				emuManager.tapAtPoint(EMULATOR_NUMBER, explore.getPoint());
-				sleepTask(2000);
+				sleepTask(500);
 				emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(520, 1200));
-				sleepTask(20000);
+				sleepTask(1000);
 				emuManager.tapBackButton(EMULATOR_NUMBER);
 
 			}
@@ -209,12 +209,12 @@ public class IntelligenceTask extends DelayedTask {
 
 	private void processSurvivor(DTOImageSearchResult result) {
 		emuManager.tapAtPoint(EMULATOR_NUMBER, result.getPoint());
-		sleepTask(3000);
+		sleepTask(2000);
 
 		DTOImageSearchResult view = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_VIEW.getTemplate(), 0, 0, 720, 1280, 90);
 		if (view.isFound()) {
 			emuManager.tapAtPoint(EMULATOR_NUMBER, view.getPoint());
-			sleepTask(3000);
+			sleepTask(500);
 			DTOImageSearchResult rescue = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_RESCUE.getTemplate(), 0, 0, 720, 1280, 90);
 			if (rescue.isFound()) {
 				emuManager.tapAtPoint(EMULATOR_NUMBER, rescue.getPoint());
@@ -240,16 +240,16 @@ public class IntelligenceTask extends DelayedTask {
 
 	private void processBeast(DTOImageSearchResult beast) {
 		emuManager.tapAtPoint(EMULATOR_NUMBER, beast.getPoint());
-		sleepTask(3000);
+		sleepTask(2000);
 
 		DTOImageSearchResult view = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_VIEW.getTemplate(), 0, 0, 720, 1280, 90);
 		if (view.isFound()) {
 			emuManager.tapAtPoint(EMULATOR_NUMBER, view.getPoint());
-			sleepTask(3000);
+			sleepTask(500);
 			DTOImageSearchResult attack = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_ATTACK.getTemplate(), 0, 0, 720, 1280, 90);
 			if (attack.isFound()) {
 				emuManager.tapAtPoint(EMULATOR_NUMBER, attack.getPoint());
-				sleepTask(3000);
+				sleepTask(500);
 				DTOImageSearchResult rally = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.INTEL_ATTACK_CONFIRM.getTemplate(), 0, 0, 720, 1280, 90);
 				if (rally.isFound()) {
 					emuManager.tapAtPoint(EMULATOR_NUMBER, rally.getPoint());

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceTask.java
@@ -11,6 +11,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class LifeEssenceTask extends DelayedTask {
@@ -65,7 +66,10 @@ public class LifeEssenceTask extends DelayedTask {
 						break;
 					}
 				}
-				this.reschedule(LocalDateTime.now().plusHours(profile.getConfig(EnumConfigurationKey.LIFE_ESSENCE_OFFSET_INT, Integer.class)));
+				LocalDateTime nextSchedule = LocalDateTime.now().plusHours(profile.getConfig(EnumConfigurationKey.LIFE_ESSENCE_OFFSET_INT, Integer.class));
+				this.reschedule(nextSchedule);
+				ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
+				
 				emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(40, 30));
 				sleepTask(3000);
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceTask.java
@@ -50,7 +50,7 @@ public class LifeEssenceTask extends DelayedTask {
 			int claim = 0;
 			if (lifeEssenceMenu.isFound()) {
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, lifeEssenceMenu.getPoint(), lifeEssenceMenu.getPoint());
-				sleepTask(5000);
+				sleepTask(3000);
 				emuManager.tapBackButton(EMULATOR_NUMBER);
 				emuManager.tapBackButton(EMULATOR_NUMBER);
 				servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Searching for life essence");
@@ -71,7 +71,7 @@ public class LifeEssenceTask extends DelayedTask {
 				ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
 				
 				emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(40, 30));
-				sleepTask(3000);
+				sleepTask(1000);
 
 			} else {
 				System.out.println("Life essence menu not found");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTask.java
@@ -11,6 +11,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class MailRewardsTask extends DelayedTask {
@@ -36,7 +37,9 @@ public class MailRewardsTask extends DelayedTask {
 				sleepTask(1000);
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(420, 1227), new DTOPoint(450, 1250), 10, 100);
 			}
-			this.reschedule(LocalDateTime.now().plusHours(profile.getConfig(EnumConfigurationKey.MAIL_REWARDS_OFFSET_INT, Integer.class)));
+			LocalDateTime nextSchedule = LocalDateTime.now().plusHours(profile.getConfig(EnumConfigurationKey.MAIL_REWARDS_OFFSET_INT, Integer.class));
+			this.reschedule(nextSchedule);
+			ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
 			EmulatorManager.getInstance().tapBackButton(EMULATOR_NUMBER);
 
 		} else {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTask.java
@@ -31,7 +31,7 @@ public class MailRewardsTask extends DelayedTask {
 			sleepTask(1000);
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "going to mail");
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(640, 1033), new DTOPoint(686, 1064));
-			sleepTask(3000);
+			sleepTask(1000);
 			for (DTOPoint button : buttons) {
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, button, button);
 				sleepTask(1000);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/OnlineRewardTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/OnlineRewardTask.java
@@ -40,22 +40,22 @@ public class OnlineRewardTask extends DelayedTask {
 			}
 
 			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(3, 513), new DTOPoint(26, 588));
-			sleepTask(2000);
+			sleepTask(500);
 
 			EmulatorManager.getInstance().tapAtPoint(EMULATOR_NUMBER, new DTOPoint(110, 270));
-			sleepTask(1000);
+			sleepTask(500);
 
 			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(20, 250), new DTOPoint(200, 280));
-			sleepTask(2000);
+			sleepTask(500);
 
 			DTOImageSearchResult researchCenter = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_SHORTCUTS_RESEARCH_CENTER.getTemplate(), 0, 0, 720, 1280, 90);
 
 			if (researchCenter.isFound()) {
 				{
 					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, researchCenter.getPoint(), researchCenter.getPoint());
-					sleepTask(2000);
+					sleepTask(500);
 					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(30, 430), new DTOPoint(50, 470));
-					sleepTask(2000);
+					sleepTask(500);
 
 					DTOImageSearchResult chest = null;
 					System.out.println("Searching for chest");
@@ -68,7 +68,7 @@ public class OnlineRewardTask extends DelayedTask {
 							System.out.println("Chest found, tapping");
 							servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Claiming chest");
 							emuManager.tapAtRandomPoint(EMULATOR_NUMBER, chest.getPoint(), chest.getPoint());
-							sleepTask(2000);
+							sleepTask(500);
 
 							emuManager.tapBackButton(EMULATOR_NUMBER);
 							for (int j = 0; j < 5; j++) {
@@ -77,9 +77,9 @@ public class OnlineRewardTask extends DelayedTask {
 								if (stamina.isFound()) {
 									servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Claiming stamina");
 									emuManager.tapAtRandomPoint(EMULATOR_NUMBER, stamina.getPoint(), stamina.getPoint());
-									sleepTask(2000);
+									sleepTask(500);
 									emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(250, 930), new DTOPoint(450, 950));
-									sleepTask(6000);
+									sleepTask(3000);
 									break;
 								} else {
 									System.out.println("Stamina not found, sleeping");
@@ -104,9 +104,9 @@ public class OnlineRewardTask extends DelayedTask {
 							if (stamina.isFound()) {
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Claiming stamina");
 								emuManager.tapAtRandomPoint(EMULATOR_NUMBER, stamina.getPoint(), stamina.getPoint());
-								sleepTask(2000);
+								sleepTask(500);
 								emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(250, 930), new DTOPoint(450, 950));
-								sleepTask(6000);
+								sleepTask(3000);
 								break;
 							} else {
 								System.out.println("Stamina not found, sleeping");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAdventureChestTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAdventureChestTask.java
@@ -50,7 +50,7 @@ public class PetAdventureChestTask extends DelayedTask {
 				DTOImageSearchResult beastCageResult = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_BEAST_CAGE.getTemplate(), 0, 0, 720, 1280, 90);
 				if (beastCageResult.isFound()) {
 					emuManager.tapAtPoint(EMULATOR_NUMBER, beastCageResult.getPoint());
-					sleepTask(3000);
+					sleepTask(500);
 					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(547, 1150), new DTOPoint(650, 1210));
 
 					for (int i = 0; i < 10; i++) {
@@ -58,14 +58,14 @@ public class PetAdventureChestTask extends DelayedTask {
 						DTOImageSearchResult doneChest = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_CHEST_COMPLETED.getTemplate(), 0, 0, 720, 1280, 90);
 						if (doneChest.isFound()) {
 							emuManager.tapAtRandomPoint(EMULATOR_NUMBER, doneChest.getPoint(), doneChest.getPoint());
-							sleepTask(1000);
+							sleepTask(500);
 							emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(270, 735), new DTOPoint(450, 760), 20, 100);
 
 							DTOImageSearchResult share = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_CHEST_SHARE.getTemplate(), 0, 0, 720, 1280, 90);
 							if (share.isFound()) {
 								servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Sharing chest");
 								emuManager.tapAtRandomPoint(EMULATOR_NUMBER, share.getPoint(), share.getPoint());
-								sleepTask(1000);
+								sleepTask(500);
 							}
 							emuManager.tapBackButton(EMULATOR_NUMBER);
 							sleepTask(500);
@@ -90,22 +90,22 @@ public class PetAdventureChestTask extends DelayedTask {
 									servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Found: " + enumTemplates);
 
 									emuManager.tapAtRandomPoint(EMULATOR_NUMBER, result.getPoint(), result.getPoint());
-									sleepTask(2000);
+									sleepTask(500);
 
 									DTOImageSearchResult chestSelect = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_CHEST_SELECT.getTemplate(), 0, 0, 720, 1280, 90);
 
 									if (chestSelect.isFound()) {
 										emuManager.tapAtPoint(EMULATOR_NUMBER, chestSelect.getPoint());
-										sleepTask(2000);
+										sleepTask(500);
 
 										DTOImageSearchResult chestStart = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_CHEST_START.getTemplate(), 0, 0, 720, 1280, 90);
 
 										if (chestStart.isFound()) {
 											emuManager.tapAtPoint(EMULATOR_NUMBER, chestStart.getPoint());
-											sleepTask(2000);
+											sleepTask(500);
 
 											emuManager.tapBackButton(EMULATOR_NUMBER);
-											sleepTask(1000);
+											sleepTask(500);
 											break; // Sale del intento, pero no del ciclo principal
 										} else {
 											DTOImageSearchResult attempts = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_CHEST_ATTEMPT.getTemplate(), 0, 0, 720, 1280, 90);
@@ -127,7 +127,7 @@ public class PetAdventureChestTask extends DelayedTask {
 
 						if (foundAnyChest) {
 							servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "At least one chest was found. Restarting search...");
-							sleepTask(5000); // Espera 5 segundos antes de repetir
+							sleepTask(500); // Espera 5 segundos antes de repetir
 						}
 
 					} while (foundAnyChest); // El bucle se repite hasta que no se encuentren más cofres

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAllianceTreasuresTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAllianceTreasuresTask.java
@@ -37,14 +37,14 @@ public class PetAllianceTreasuresTask extends DelayedTask {
 			if (petsResult.isFound()) {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "button pets found, taping");
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, petsResult.getPoint(), petsResult.getPoint());
-				sleepTask(5000);
+				sleepTask(3000);
 
 				DTOImageSearchResult beastCageResult = EmulatorManager.getInstance().searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_BEAST_CAGE.getTemplate(), 0, 0, 720, 1280, 90);
 				if (beastCageResult.isFound()) {
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, beastCageResult.getPoint(), beastCageResult.getPoint());
-					sleepTask(3000);
+					sleepTask(500);
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(547, 1150), new DTOPoint(650, 1210));
-					sleepTask(3000);
+					sleepTask(500);
 
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(612, 1184), new DTOPoint(653, 1211));
 					sleepTask(500);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetSkillsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetSkillsTask.java
@@ -72,7 +72,7 @@ public class PetSkillsTask extends DelayedTask {
 			if (petsResult.isFound()) {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "button pets found, taping");
 				EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, petsResult.getPoint(), petsResult.getPoint());
-				sleepTask(5000);
+				sleepTask(1000);
 
 				emuManager.tapAtRandomPoint(EMULATOR_NUMBER, petSkill.getPoint1(), petSkill.getPoint2());
 				sleepTask(300);
@@ -98,7 +98,7 @@ public class PetSkillsTask extends DelayedTask {
 				DTOImageSearchResult skillButton = EmulatorManager.getInstance().searchTemplate(EMULATOR_NUMBER, EnumTemplates.PETS_SKILL_USE.getTemplate(), 0, 0, 720, 1280, 90);
 				if (skillButton.isFound()) {
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, skillButton.getPoint(), skillButton.getPoint(), 10, 100);
-					sleepTask(2000);
+					sleepTask(500);
 				}
 
 				try {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TrainingTroopsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TrainingTroopsTask.java
@@ -15,6 +15,7 @@ import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.serv.impl.ServLogs;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 import net.sourceforge.tess4j.TesseractException;
 
@@ -87,7 +88,9 @@ public class TrainingTroopsTask extends DelayedTask {
 					Optional<LocalDateTime> optionalNextTime = extractNextTime();
 
 					if (optionalNextTime.isPresent()) {
-						this.reschedule(optionalNextTime.get());
+						LocalDateTime nextSchedule = optionalNextTime.get();
+						this.reschedule(nextSchedule);
+						ServScheduler.getServices().updateDailyTaskStatus(profile, TpDailyTaskEnum.TRAINING_TROOPS, nextSchedule);
 					}
 
 					EmulatorManager.getInstance().tapBackButton(EMULATOR_NUMBER);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TrainingTroopsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TrainingTroopsTask.java
@@ -56,9 +56,9 @@ public class TrainingTroopsTask extends DelayedTask {
 
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "going training " + troopType);
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(3, 513), new DTOPoint(26, 588));
-			sleepTask(2000);
-			EmulatorManager.getInstance().tapAtPoint(EMULATOR_NUMBER, new DTOPoint(110, 270));
 			sleepTask(1000);
+			EmulatorManager.getInstance().tapAtPoint(EMULATOR_NUMBER, new DTOPoint(110, 270));
+			sleepTask(500);
 
 			DTOImageSearchResult troopsResult = EmulatorManager.getInstance().searchTemplate(EMULATOR_NUMBER, troopType.getTemplate(), 0, 0, 720, 1280, 90);
 
@@ -72,7 +72,7 @@ public class TrainingTroopsTask extends DelayedTask {
 
 				if (trainingResult.isFound()) {
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, trainingResult.getPoint(), trainingResult.getPoint());
-					sleepTask(2000);
+					sleepTask(500);
 
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(222, 157), new DTOPoint(504, 231), 10, 100);
 
@@ -81,7 +81,7 @@ public class TrainingTroopsTask extends DelayedTask {
 					if (trainingButtonResult.isFound()) {
 						ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "Training available, taping");
 						EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, trainingButtonResult.getPoint(), trainingButtonResult.getPoint());
-						sleepTask(3000);
+						sleepTask(500);
 					}
 
 					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "getting next training schedule");
@@ -94,7 +94,7 @@ public class TrainingTroopsTask extends DelayedTask {
 					}
 
 					EmulatorManager.getInstance().tapBackButton(EMULATOR_NUMBER);
-					sleepTask(2000);
+					sleepTask(500);
 				}
 			} else {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.WARNING, taskName, profile.getName(), "Troops not found");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/VipTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/VipTask.java
@@ -35,22 +35,22 @@ public class VipTask extends DelayedTask {
 				if (monthlyVip.isFound()) {
 					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "VIP not active, buying monthly vip");
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, monthlyVip.getPoint(), monthlyVip.getPoint());
-					sleepTask(3000);
+					sleepTask(1000);
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(520, 810), new DTOPoint(650, 850));
-					sleepTask(2000);
+					sleepTask(500);
 					EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(250, 770), new DTOPoint(480, 800));
-					sleepTask(1000);
+					sleepTask(500);
 					EmulatorManager.getInstance().tapBackButton(EMULATOR_NUMBER);
-					sleepTask(1000);
+					sleepTask(500);
 
 				}
 			}
 
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(540, 813), new DTOPoint(624, 835), 7, 300);
-			sleepTask(5000);
+			sleepTask(500);
 
 			EmulatorManager.getInstance().tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(602, 263), new DTOPoint(650, 293), 7, 300);
-			sleepTask(3000);
+			sleepTask(500);
 
 			reschedule(UtilTime.getGameReset());
 			ServScheduler.getServices().updateDailyTaskStatus(profile, TpDailyTaskEnum.VIP_POINTS, UtilTime.getGameReset());


### PR DESCRIPTION
I am running 10 emulators 7/24 with the bot now (thanks to you @camoloqlo such and amazing work again thank you!) and all these features and fixes helped me a lot to utilize the bot for continuous work for multiple instances. So if you feel like it's too much or doesn't serve the purpose of this project feel free to ignore this pull request.

### Refactors
- Added continuous intel processing on single run to utilize march slots. With this update, bot will use multiple march queue slot for intels instead of just one. Also pressing equalize button on troops selection to equalize troops.
- Reduced delays on various tasks to speed up processing time. (Many tasks were waiting more than it should for some operations, I don't know if this was intentional for lower system specs but with lower sleeps I was able to run 10 emulators without any issue so I kept it but can be discarded if intentionally made long sleeps)

### New Features
- Added pause functionality to the application
- Added an option on gathering page to activate Gathering speed boost (250 gems) to speed up gathering
- Delay gathering task for 2 minutes if Intel is enabled and not completed yet (This will help users with low march queue.  First Intels will be processed and then gathering will start so even with low march queue, both operations will be handled)
- Delay gathering task for 2 minutes if gathering boost is active and not yet activated. (If gathering boost is enabled, make sure gathering boost is activated before starting gathering.)

### Fixes
- Added missing database update on rescheduling for various tasks to prevent tasks replaying over and over on application restart.
- Added march queue limit option to gathering to prevent errors and loops if march slot is lower than 6. User can config their slot limit on gathering tab for better functionality.