### PR TITLE
Added a profile filter to logs and fixed a bug on task manager

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/console/view/ConsoleLogLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/console/view/ConsoleLogLayoutController.java
@@ -92,8 +92,7 @@ public class ConsoleLogLayoutController {
 
 	@FXML
 	void handleButtonResetProfileFilter(ActionEvent event) {
-		comboBoxProfileFilter.setValue(null);
-		comboBoxProfileFilter.getSelectionModel().clearSelection();
+		comboBoxProfileFilter.getSelectionModel().selectFirst(); // Select "All profiles"
 		updateLogFilter();
 	}
 
@@ -103,8 +102,10 @@ public class ConsoleLogLayoutController {
 			List<DTOProfiles> profiles = ServProfiles.getServices().getProfiles();
 			if (profiles != null) {
 				ObservableList<String> profileNames = FXCollections.observableArrayList();
+				profileNames.add("All profiles");
 				profiles.forEach(profile -> profileNames.add(profile.getName()));
 				comboBoxProfileFilter.setItems(profileNames);
+				comboBoxProfileFilter.getSelectionModel().selectFirst(); // Select "All profiles" by default
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -122,7 +123,7 @@ public class ConsoleLogLayoutController {
 		filteredLogMessages.setPredicate(logMessage -> {
 			// Profile filter
 			String selectedProfile = comboBoxProfileFilter.getValue();
-			if (selectedProfile != null && !selectedProfile.isEmpty()) {
+			if (selectedProfile != null && !selectedProfile.isEmpty() && !"All profiles".equals(selectedProfile)) {
 				String messageProfile = logMessage.profileProperty().get();
 				if (messageProfile == null || !messageProfile.equals(selectedProfile)) {
 					return false;

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/console/view/ConsoleLogLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/console/view/ConsoleLogLayout.fxml
@@ -3,6 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.ColumnConstraints?>
@@ -41,6 +42,16 @@
                   <Insets />
                </HBox.margin>
             </CheckBox>
+            <ComboBox fx:id="comboBoxProfileFilter" prefWidth="120.0" promptText="All Profiles" HBox.hgrow="NEVER">
+               <HBox.margin>
+                  <Insets right="5.0" />
+               </HBox.margin>
+            </ComboBox>
+            <Button fx:id="buttonResetProfileFilter" mnemonicParsing="false" onAction="#handleButtonResetProfileFilter" text="Reset filter" HBox.hgrow="NEVER">
+               <HBox.margin>
+                  <Insets right="10.0" />
+               </HBox.margin>
+            </Button>
             <Button fx:id="buttonClearLogs" mnemonicParsing="false" onAction="#handleButtonClearLogs" text="Clear Logs" HBox.hgrow="NEVER">
                <HBox.margin>
                   <Insets />

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/console/view/ConsoleLogLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/console/view/ConsoleLogLayout.fxml
@@ -42,7 +42,7 @@
                   <Insets />
                </HBox.margin>
             </CheckBox>
-            <ComboBox fx:id="comboBoxProfileFilter" prefWidth="120.0" promptText="All Profiles" HBox.hgrow="NEVER">
+            <ComboBox fx:id="comboBoxProfileFilter" prefWidth="120.0" HBox.hgrow="NEVER">
                <HBox.margin>
                   <Insets right="5.0" />
                </HBox.margin>

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -269,7 +269,6 @@ public class ServScheduler {
 							taskState.setTaskId(task.getTpTask().getId());
 							taskState.setExecuting(false);
 							taskState.setScheduled(true);
-							taskState.setNextExecutionTime(task.getScheduled());
 							
 							if (taskSchedules.containsKey(task.getTpDailyTaskId())) {
 								DTODailyTaskStatus taskStatus = taskSchedules.get(task.getTpDailyTaskId());
@@ -285,6 +284,7 @@ public class ServScheduler {
 								taskState.setLastExecutionTime(null); // No previous execution
 							}
 
+							taskState.setNextExecutionTime(task.getScheduled());
 							ServTaskManager.getInstance().setTaskState(profile.getId(), taskState);
 							queue.addTask(task);
 						}


### PR DESCRIPTION
- Added a profile filter to logs
- Fixed a bug showing next schedule always ready in task manager. setNextExecutionTime runs before the nextSchedule sets and this cause next execution on taskState always now. [[1]](diffhunk://#diff-c70f0fc5ea5d335fdfd153454ecc076f3721480df178df9ad38697f957bc43a3R287)