### PR TITLE
Couple Bug Fixes and Speedup launch time

### DIFF
--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import cl.camodev.utiles.UtilTime;
 import cl.camodev.wosbot.console.enumerable.EnumConfigurationKey;
+import cl.camodev.wosbot.console.enumerable.EnumTemplates;
 import cl.camodev.wosbot.console.enumerable.EnumTpMessageSeverity;
 import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
 import cl.camodev.wosbot.emulator.EmulatorManager;
@@ -18,6 +19,7 @@ import cl.camodev.wosbot.ex.ADBConnectionException;
 import cl.camodev.wosbot.ex.HomeNotFoundException;
 import cl.camodev.wosbot.ex.ProfileInReconnectStateException;
 import cl.camodev.wosbot.ex.StopExecutionException;
+import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOProfileStatus;
 import cl.camodev.wosbot.ot.DTOProfiles;
 import cl.camodev.wosbot.ot.DTOTaskState;
@@ -41,6 +43,7 @@ public class TaskQueue {
 	// Hilo que se encargará de evaluar y ejecutar las tareas.
 	private Thread schedulerThread;
 	private DTOProfiles profile;
+	protected EmulatorManager emuManager = EmulatorManager.getInstance();
 
 	public TaskQueue(DTOProfiles profile) {
 		this.profile = profile;
@@ -190,6 +193,13 @@ public class TaskQueue {
 									paused = false;
 									ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "RESUMING AFTER PAUSE"));
 									logger.info("TaskQueue resumed for profile {} after {} minutes pause", profile.getName(), reconnectionTime);
+									
+									// Click reconnect button if found and reinitialize the task
+									DTOImageSearchResult reconnect = emuManager.searchTemplate(profile.getEmulatorNumber(), EnumTemplates.GAME_HOME_RECONNECT.getTemplate(), 90);
+									if (reconnect.isFound()) {
+										emuManager.tapAtPoint(profile.getEmulatorNumber(), reconnect.getPoint());
+									}
+
 									addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
 								}
 							}).start();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
@@ -149,122 +149,123 @@ public class TaskQueue {
 					}
 
 
-				// Remover la tarea de la cola
-				taskQueue.poll();
-				LocalDateTime scheduledBefore = task.getScheduled();
-				try {
-					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Starting task execution");
-					ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "Executing " + task.getTaskName()));
+					// Remover la tarea de la cola
+					taskQueue.poll();
+					LocalDateTime scheduledBefore = task.getScheduled();
+					try {
+						ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Starting task execution");
+						ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "Executing " + task.getTaskName()));
 
-					taskState = new DTOTaskState();
-					taskState.setProfileId(profile.getId());
-					taskState.setTaskId(task.getTpDailyTaskId());
-					taskState.setScheduled(true);
-					taskState.setExecuting(true);
+						taskState = new DTOTaskState();
+						taskState.setProfileId(profile.getId());
+						taskState.setTaskId(task.getTpDailyTaskId());
+						taskState.setScheduled(true);
+						taskState.setExecuting(true);
+						taskState.setLastExecutionTime(LocalDateTime.now());
+						taskState.setNextExecutionTime(task.getScheduled());
+						ServTaskManager.getInstance().setTaskState(profile.getId(), taskState);
+
+
+						task.run();
+
+					} catch (HomeNotFoundException e) {
+						ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, task.getTaskName(), profile.getName(), e.getMessage());
+						logger.error("Error executing task " + task.getTaskName() + " for profile " + profile.getName() + ": " + e.getMessage(), e);
+						addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
+					} catch (StopExecutionException e) {
+						logger.error("Execution stopped for task " + task.getTaskName() + " for profile " + profile.getName() + ": " + e.getMessage(), e);
+						stop();
+					} catch (ProfileInReconnectStateException e) {
+						Long reconnectionTime = profile.getReconnectionTime();
+						if (reconnectionTime != null && reconnectionTime > 0) {
+							ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Profile in reconnect state before executing task, pausing queue for " + reconnectionTime + " minutes");
+							logger.info("Profile {} is in reconnect state, pausing TaskQueue for {} minutes", profile.getName(), reconnectionTime);
+							paused = true;
+							new Thread(() -> {
+								try {
+									Thread.sleep(TimeUnit.MINUTES.toMillis(reconnectionTime));
+								} catch (InterruptedException ignored) { }
+
+								if (paused) {
+									paused = false;
+									ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "RESUMING AFTER PAUSE"));
+									logger.info("TaskQueue resumed for profile {} after {} minutes pause", profile.getName(), reconnectionTime);
+									addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
+								}
+							}).start();
+							break; // Exit the loop to wait for reconnection
+						} else {
+							ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, task.getTaskName(), profile.getName(), "Profile in reconnect state, but no reconnection time set");
+							logger.error("Profile {} is in reconnect state, but no reconnection time set, resuming execution", profile.getName());
+							addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
+						}
+					} catch (ADBConnectionException e) {
+						logger.error("ADB connection error executing task {} for profile {}: {}", task.getTaskName(), profile.getName(), e.getMessage(), e);
+						addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
+					} catch (Exception e) {
+						ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, task.getTaskName(), profile.getName(), e.getMessage());
+						logger.error("Error executing task " + task.getTaskName() + " for profile " + profile.getName() + ": " + e.getMessage(), e);
+					}
+					LocalDateTime scheduledAfter = task.getScheduled();
+					if (scheduledBefore.equals(scheduledAfter)) {
+						logger.info("Task {} for profile {} executed without rescheduling, changing scheduled time to now to avoid infinite loop", task.getTaskName(), profile.getName());
+						task.reschedule(LocalDateTime.now());
+					}
+
+					if (task.isRecurring()) {
+						ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Next schedule: " + UtilTime.localDateTimeToDDHHMMSS(task.getScheduled()));
+						addTask(task);
+					} else {
+						ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Task removed from schedule");
+					}
+
+					boolean dailyAutoSchedule = profile.getConfig(EnumConfigurationKey.DAILY_MISSION_AUTO_SCHEDULE_BOOL, Boolean.class);
+					if (dailyAutoSchedule) {
+						DTOTaskState state = ServTaskManager.getInstance().getTaskState(profile.getId(), TpDailyTaskEnum.DAILY_MISSIONS.getId());
+						LocalDateTime next = (state != null) ? state.getNextExecutionTime() : null;
+						LocalDateTime now = LocalDateTime.now();
+						if (task.provideDailyMissionProgress() && (state == null || next == null || next.isAfter(now))) {
+							DelayedTask prototype = DelayedTaskRegistry.create(TpDailyTaskEnum.DAILY_MISSIONS, profile);
+
+							// verify if the task already exists in the queue
+							DelayedTask existing = taskQueue.stream().filter(prototype::equals).findFirst().orElse(null);
+
+							if (existing != null) {
+								// task already exists, reschedule it to run now
+								taskQueue.remove(existing);
+								existing.reschedule(LocalDateTime.now());
+								existing.setRecurring(true);
+								taskQueue.offer(existing);
+
+								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, "TaskQueue", profile.getName(), "Rescheduled existing " + TpDailyTaskEnum.DAILY_MISSIONS + " to run now");
+							} else {
+								// task does not exist, create a new instance and schedule it just once
+								prototype.reschedule(LocalDateTime.now());
+								prototype.setRecurring(false);
+								taskQueue.offer(prototype);
+								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, "TaskQueue", profile.getName(), "Enqueued new immediate " + TpDailyTaskEnum.DAILY_MISSIONS);
+							}
+
+
+						}
+					}
+
+
+					if (task.provideTriumphProgress()) {
+
+					}
+
+					assert taskState != null;
+					taskState.setExecuting(false);
+					taskState.setScheduled(task.isRecurring());
 					taskState.setLastExecutionTime(LocalDateTime.now());
 					taskState.setNextExecutionTime(task.getScheduled());
+
 					ServTaskManager.getInstance().setTaskState(profile.getId(), taskState);
+					ServScheduler.getServices().updateDailyTaskStatus(profile, task.getTpTask(), task.getScheduled());
 
-
-					task.run();
-
-				} catch (HomeNotFoundException e) {
-					ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, task.getTaskName(), profile.getName(), e.getMessage());
-					logger.error("Error executing task " + task.getTaskName() + " for profile " + profile.getName() + ": " + e.getMessage(), e);
-					addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
-				} catch (StopExecutionException e) {
-					logger.error("Execution stopped for task " + task.getTaskName() + " for profile " + profile.getName() + ": " + e.getMessage(), e);
-					stop();
-				} catch (ProfileInReconnectStateException e) {
-					Long reconnectionTime = profile.getReconnectionTime();
-					if (reconnectionTime != null && reconnectionTime > 0) {
-						ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Profile in reconnect state before executing task, pausing queue for " + reconnectionTime + " minutes");
-						logger.info("Profile {} is in reconnect state, pausing TaskQueue for {} minutes", profile.getName(), reconnectionTime);
-						paused = true;
-						new Thread(() -> {
-							try {
-								Thread.sleep(TimeUnit.MINUTES.toMillis(reconnectionTime));
-							} catch (InterruptedException ignored) {
-							}
-							if (paused) {
-								paused = false;
-								ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "RESUMING AFTER PAUSE"));
-								logger.info("TaskQueue resumed for profile {} after {} minutes pause", profile.getName(), reconnectionTime);
-								addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
-							}
-						}).start();
-					} else {
-						ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, task.getTaskName(), profile.getName(), "Profile in reconnect state, but no reconnection time set");
-						logger.error("Profile {} is in reconnect state, but no reconnection time set, resuming execution", profile.getName());
-						addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
-					}
-				} catch (ADBConnectionException e) {
-					logger.error("ADB connection error executing task {} for profile {}: {}", task.getTaskName(), profile.getName(), e.getMessage(), e);
-					addTask(new InitializeTask(profile, TpDailyTaskEnum.INITIALIZE));
-				} catch (Exception e) {
-					ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, task.getTaskName(), profile.getName(), e.getMessage());
-					logger.error("Error executing task " + task.getTaskName() + " for profile " + profile.getName() + ": " + e.getMessage(), e);
+					executedTask = true;
 				}
-				LocalDateTime scheduledAfter = task.getScheduled();
-				if (scheduledBefore.equals(scheduledAfter)) {
-					logger.info("Task {} for profile {} executed without rescheduling, changing scheduled time to now to avoid infinite loop", task.getTaskName(), profile.getName());
-					task.reschedule(LocalDateTime.now());
-				}
-
-				if (task.isRecurring()) {
-					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Next schedule: " + UtilTime.localDateTimeToDDHHMMSS(task.getScheduled()));
-					addTask(task);
-				} else {
-					ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Task removed from schedule");
-				}
-
-				boolean dailyAutoSchedule = profile.getConfig(EnumConfigurationKey.DAILY_MISSION_AUTO_SCHEDULE_BOOL, Boolean.class);
-				if (dailyAutoSchedule) {
-					DTOTaskState state = ServTaskManager.getInstance().getTaskState(profile.getId(), TpDailyTaskEnum.DAILY_MISSIONS.getId());
-					LocalDateTime next = (state != null) ? state.getNextExecutionTime() : null;
-					LocalDateTime now = LocalDateTime.now();
-					if (task.provideDailyMissionProgress() && (state == null || next == null || next.isAfter(now))) {
-						DelayedTask prototype = DelayedTaskRegistry.create(TpDailyTaskEnum.DAILY_MISSIONS, profile);
-
-						// verify if the task already exists in the queue
-						DelayedTask existing = taskQueue.stream().filter(prototype::equals).findFirst().orElse(null);
-
-						if (existing != null) {
-							// task already exists, reschedule it to run now
-							taskQueue.remove(existing);
-							existing.reschedule(LocalDateTime.now());
-							existing.setRecurring(true);
-							taskQueue.offer(existing);
-
-							ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, "TaskQueue", profile.getName(), "Rescheduled existing " + TpDailyTaskEnum.DAILY_MISSIONS + " to run now");
-						} else {
-							// task does not exist, create a new instance and schedule it just once
-							prototype.reschedule(LocalDateTime.now());
-							prototype.setRecurring(false);
-							taskQueue.offer(prototype);
-							ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, "TaskQueue", profile.getName(), "Enqueued new immediate " + TpDailyTaskEnum.DAILY_MISSIONS);
-						}
-
-
-					}
-				}
-
-
-				if (task.provideTriumphProgress()) {
-
-				}
-
-				assert taskState != null;
-				taskState.setExecuting(false);
-				taskState.setScheduled(task.isRecurring());
-				taskState.setLastExecutionTime(LocalDateTime.now());
-				taskState.setNextExecutionTime(task.getScheduled());
-
-				ServTaskManager.getInstance().setTaskState(profile.getId(), taskState);
-				ServScheduler.getServices().updateDailyTaskStatus(profile, task.getTpTask(), task.getScheduled());
-
-				executedTask = true;
-			}
 
 				// Si no se ejecutó ninguna tarea, obtener el delay de la próxima tarea
 				if (!executedTask && !taskQueue.isEmpty()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
@@ -302,7 +302,8 @@ public class TaskQueue {
 						} else {
 							DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 							// Convertir minDelay (segundos) a formato HH:mm:ss
-							formattedTime = LocalTime.ofSecondOfDay(minDelay).format(timeFormatter);
+							long safeDelay = Math.max(0, minDelay);
+							formattedTime = LocalTime.ofSecondOfDay(safeDelay).format(timeFormatter);
 						}
 
 						ServProfiles.getServices().notifyProfileStatusChange(new DTOProfileStatus(profile.getId(), "Idling for " + formattedTime + "\nNext task: " + (taskQueue.isEmpty() ? "None" : taskQueue.peek().getTaskName())));

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherTask.java
@@ -66,11 +66,11 @@ public class GatherTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        // Check if IntelligenceTask is not processed yet or reschedule time is lower
-        // than 60 minutes
+        // If IntelligenceTask remaining minutes is less than 60, we will wait until it is processed
+        // if there is no remaining time, we will proceed with gathering
         long intelRemainingMinutes = isIntelligenceTaskReadyForGathering();
-        if (profile.getConfig(EnumConfigurationKey.INTEL_BOOL, Boolean.class) && intelRemainingMinutes > 0) {
-            logInfo("Waiting for IntelligenceTask to be processed or reschedule time to exceed intel remaining minutes");
+        if (profile.getConfig(EnumConfigurationKey.INTEL_BOOL, Boolean.class) && intelRemainingMinutes > 0 & intelRemainingMinutes < 60) {
+            logInfo("Waiting for IntelligenceTask to be processed since remaining time is less than 60 minutes.");
             reschedule(LocalDateTime.now().plusMinutes(intelRemainingMinutes)); // Check again in intelRemaining minutes
             return;
         }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/InitializeTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/InitializeTask.java
@@ -4,6 +4,7 @@ import cl.camodev.wosbot.console.enumerable.EnumTemplates;
 import cl.camodev.wosbot.console.enumerable.EnumTpMessageSeverity;
 import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
 import cl.camodev.wosbot.emulator.EmulatorManager;
+import cl.camodev.wosbot.ex.ProfileInReconnectStateException;
 import cl.camodev.wosbot.ex.StopExecutionException;
 import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOProfiles;
@@ -29,8 +30,8 @@ public class InitializeTask extends DelayedTask {
 			} else {
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "emulator not found, trying to start it");
 				EmulatorManager.getInstance().launchEmulator(EMULATOR_NUMBER);
-				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "waiting 30 seconds before checking again");
-				sleepTask(30000);
+				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "waiting 10 seconds before checking again");
+				sleepTask(10000);
 			}
 
 		}
@@ -42,11 +43,10 @@ public class InitializeTask extends DelayedTask {
 
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "launching game");
 			EmulatorManager.getInstance().launchApp(EMULATOR_NUMBER, EmulatorManager.WHITEOUT_PACKAGE);
-			sleepTask(15000);
+			sleepTask(10000);
 
 			final int MAX_ATTEMPTS = 10;
 			final int WAIT_TIME = 5000;
-			final int RECONNECT_WAIT = 4000;
 
 			boolean homeScreen = false;
 			int attempts = 0;
@@ -62,8 +62,7 @@ public class InitializeTask extends DelayedTask {
 
 				DTOImageSearchResult reconnect = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.GAME_HOME_RECONNECT.getTemplate(), 90);
 				if (reconnect.isFound()) {
-					tapPoint(reconnect.getPoint());
-					sleepTask(RECONNECT_WAIT);
+					throw new ProfileInReconnectStateException("Profile " + profile.getName() + " is in reconnect state, cannot execute task: " + taskName);
 				}
 
 				ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), "screen not found, esperando 5 segundos antes de volver a intentar");


### PR DESCRIPTION
fix: Added break to taskqueue reconnection logic to fix a bug.
fix: Instead of clicking reconnect on initializeTask, added an exception to prevent reconnect conflict between bot and user.
fix: Reduced unnecessary wait time on initializeTask.
fix: Added time limit to gathgering task waiting for intelligence to utilize gathering.
fix: Fixing bugs causing reconnect taks to hang or giving exception.
fix: Clicking reconnect button after resuming to prevent reconnect idling loop

_Note: Don't get confused most of these diffs were tab fix but somehow git recognized as whole code change._