### PR TITLE
feat: reschedule Alliance Mobilization task to next Monday when event is inactive

### DIFF
--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceMobilizationTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceMobilizationTask.java
@@ -27,7 +27,6 @@ public class AllianceMobilizationTask extends DelayedTask {
 
     public AllianceMobilizationTask(DTOProfiles profile, TpDailyTaskEnum tpTask) {
         super(profile, tpTask);
-        // TODO: Add scheduling logic if needed, similar to ArenaTask
     }
 
     @Override
@@ -47,9 +46,9 @@ public class AllianceMobilizationTask extends DelayedTask {
 
         // Navigate to the Alliance Mobilization screen
         if (!navigateToAllianceMobilization()) {
-            logInfo("Failed to navigate. Retrying in 5 minutes.");
-            LocalDateTime nextRun = LocalDateTime.now().plusMinutes(5);
-            this.reschedule(nextRun);
+            LocalDateTime nextMonday = UtilTime.getNextMondayUtc();
+            logInfo("Failed to navigate. Event may not be active. Retrying on next Monday at " + nextMonday + ".");
+            this.reschedule(nextMonday);
             return;
         }
 
@@ -547,7 +546,6 @@ public class AllianceMobilizationTask extends DelayedTask {
 
         // Decision logic based on points, enabled status, and whether another task is running
         boolean pointsMeetMinimum = detectedPoints >= minimumPoints;
-        boolean taskIsGood = isTaskTypeEnabled && pointsMeetMinimum;
 
         if (!isTaskTypeEnabled) {
             logInfo("→ Refreshing (disabled)");

--- a/wos-utiles/src/main/java/cl/camodev/utiles/UtilTime.java
+++ b/wos-utiles/src/main/java/cl/camodev/utiles/UtilTime.java
@@ -116,6 +116,25 @@ public class UtilTime {
     }
 
     /**
+     * Returns the next Monday at 00:00 UTC in the system's local timezone.
+     * If it's already Monday before midnight UTC, returns next week's Monday.
+     *
+     * @return LocalDateTime representing the next Monday at 00:00 UTC
+     */
+    public static LocalDateTime getNextMondayUtc() {
+        ZonedDateTime nowUtc = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime nextMonday = nowUtc.toLocalDate()
+                .plusDays(1)
+                .atStartOfDay(ZoneId.of("UTC"));
+
+        while (nextMonday.getDayOfWeek() != DayOfWeek.MONDAY) {
+            nextMonday = nextMonday.plusDays(1);
+        }
+
+        return nextMonday.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+    }
+
+    /**
      * Parses a time string in the format "HH:mm:ss" or "H:mm:ss" and converts it to total seconds.
      * If the input is invalid or null, returns -1.
      *


### PR DESCRIPTION

- Add UtilTime.getNextMondayUtc() method to calculate next Monday at 00:00 UTC
- Update AllianceMobilizationTask to retry on next Monday instead of 5 minutes when navigation fails
- Remove obsolete TODO comment about scheduling logic
- Remove unused taskIsGood variable