### PR TITLE
Fix readChestTimer text color OCR config

### DIFF
--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/StorehouseChest.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/StorehouseChest.java
@@ -235,7 +235,7 @@ public class StorehouseChest extends DelayedTask {
                 .setPageSegMode(DTOTesseractSettings.PageSegMode.SINGLE_LINE)
                 .setOcrEngineMode(DTOTesseractSettings.OcrEngineMode.LSTM)
                 .setRemoveBackground(true)
-                .setTextColor(new Color(255, 255, 255))
+                .setTextColor(new Color(255, 95, 95))
                 .setAllowedChars("0123456789:")
                 .build();
 


### PR DESCRIPTION
The "Next Chest Ready In" timer is in red, not white as it is currently configured.